### PR TITLE
fix compilation error with MSVC2013

### DIFF
--- a/peg-highlight/pmh_parser.c
+++ b/peg-highlight/pmh_parser.c
@@ -563,12 +563,12 @@ static pmh_element *ll_mergesort(pmh_element *list,
                                  int (*compare)(const pmh_element*,
                                                 const pmh_element*))
 {
-	pmh_element *out_head = NULL;
+    pmh_element *out_head = NULL;
 	
     if (!list)
         return NULL;
     
-	out_head = list;
+    out_head = list;
     
     /* Merge widths of doubling size until done */
     int merge_width = 1;
@@ -600,8 +600,8 @@ static pmh_element *ll_mergesort(pmh_element *list,
             
             /* Merge l & r */
             while (lsize > 0 || (rsize > 0 && r))
-			{
-				pmh_element *e = NULL;
+            {
+                pmh_element *e = NULL;
                 bool get_from_left = false;
                 if (lsize == 0)             get_from_left = false;
                 else if (rsize == 0 || !r)  get_from_left = true;
@@ -661,11 +661,11 @@ static bool extension(parser_data *p_data, int ext)
 /* return reference pmh_realelement for a given label */
 static pmh_realelement *get_reference(parser_data *p_data, char *label)
 {
-	pmh_realelement *cursor = NULL;
+    pmh_realelement *cursor = NULL;
     if (!label)
         return NULL;
 
-	cursor = p_data->references;
+    cursor = p_data->references;
     
     while (cursor != NULL)
     {
@@ -757,7 +757,7 @@ p_data->current_elem elements. Return the (list of) elements with real offsets.
 */
 static pmh_realelement *fix_offsets(parser_data *p_data, pmh_realelement *elem)
 {
-	pmh_realelement *new_head = NULL;
+    pmh_realelement *new_head = NULL;
     if (elem->type == pmh_EXTRA_TEXT)
         return mk_etext(p_data, elem->text);
     

--- a/peg-highlight/pmh_parser.c
+++ b/peg-highlight/pmh_parser.c
@@ -216,7 +216,7 @@ pmh_element_type pmh_element_type_from_name(char *name)
         if (i_name == NULL)
             continue;
         if (strcmp(i_name, name) == 0)
-            return i;
+			return (pmh_element_type)i;
     }
     
     return pmh_NO_TYPE;
@@ -563,10 +563,11 @@ static pmh_element *ll_mergesort(pmh_element *list,
                                  int (*compare)(const pmh_element*,
                                                 const pmh_element*))
 {
+	pmh_element *out_head;
     if (!list)
         return NULL;
     
-    pmh_element *out_head = list;
+	out_head = list;
     
     /* Merge widths of doubling size until done */
     int merge_width = 1;
@@ -598,13 +599,14 @@ static pmh_element *ll_mergesort(pmh_element *list,
             
             /* Merge l & r */
             while (lsize > 0 || (rsize > 0 && r))
-            {
+			{
+				pmh_element *e;
                 bool get_from_left = false;
                 if (lsize == 0)             get_from_left = false;
                 else if (rsize == 0 || !r)  get_from_left = true;
                 else if (compare(l,r) <= 0) get_from_left = true;
                 
-                pmh_element *e;
+                
                 if (get_from_left) {
                     e = l; l = l->next; lsize--;
                 } else {
@@ -658,10 +660,10 @@ static bool extension(parser_data *p_data, int ext)
 /* return reference pmh_realelement for a given label */
 static pmh_realelement *get_reference(parser_data *p_data, char *label)
 {
+	pmh_realelement *cursor = p_data->references;
     if (!label)
         return NULL;
     
-    pmh_realelement *cursor = p_data->references;
     while (cursor != NULL)
     {
         if (cursor->label && strcmp(label, cursor->label) == 0)
@@ -752,10 +754,11 @@ p_data->current_elem elements. Return the (list of) elements with real offsets.
 */
 static pmh_realelement *fix_offsets(parser_data *p_data, pmh_realelement *elem)
 {
+	pmh_realelement *new_head = NULL;
     if (elem->type == pmh_EXTRA_TEXT)
         return mk_etext(p_data, elem->text);
     
-    pmh_realelement *new_head = copy_element(p_data, elem);
+     new_head = copy_element(p_data, elem);
     
     pmh_realelement *tail = new_head;
     pmh_realelement *prev = NULL;

--- a/peg-highlight/pmh_parser.c
+++ b/peg-highlight/pmh_parser.c
@@ -601,7 +601,7 @@ static pmh_element *ll_mergesort(pmh_element *list,
             /* Merge l & r */
             while (lsize > 0 || (rsize > 0 && r))
 			{
-				pmh_element *e;
+				pmh_element *e = NULL;
                 bool get_from_left = false;
                 if (lsize == 0)             get_from_left = false;
                 else if (rsize == 0 || !r)  get_from_left = true;
@@ -661,9 +661,11 @@ static bool extension(parser_data *p_data, int ext)
 /* return reference pmh_realelement for a given label */
 static pmh_realelement *get_reference(parser_data *p_data, char *label)
 {
-	pmh_realelement *cursor = p_data->references;
+	pmh_realelement *cursor = NULL;
     if (!label)
         return NULL;
+
+	cursor = p_data->references;
     
     while (cursor != NULL)
     {
@@ -759,7 +761,7 @@ static pmh_realelement *fix_offsets(parser_data *p_data, pmh_realelement *elem)
     if (elem->type == pmh_EXTRA_TEXT)
         return mk_etext(p_data, elem->text);
     
-     new_head = copy_element(p_data, elem);
+    new_head = copy_element(p_data, elem);
     
     pmh_realelement *tail = new_head;
     pmh_realelement *prev = NULL;

--- a/peg-highlight/pmh_parser.c
+++ b/peg-highlight/pmh_parser.c
@@ -216,7 +216,7 @@ pmh_element_type pmh_element_type_from_name(char *name)
         if (i_name == NULL)
             continue;
         if (strcmp(i_name, name) == 0)
-			return (pmh_element_type)i;
+            return i;
     }
     
     return pmh_NO_TYPE;
@@ -563,7 +563,8 @@ static pmh_element *ll_mergesort(pmh_element *list,
                                  int (*compare)(const pmh_element*,
                                                 const pmh_element*))
 {
-	pmh_element *out_head;
+	pmh_element *out_head = NULL;
+	
     if (!list)
         return NULL;
     

--- a/peg-highlight/pmh_parser.c
+++ b/peg-highlight/pmh_parser.c
@@ -607,7 +607,6 @@ static pmh_element *ll_mergesort(pmh_element *list,
                 else if (rsize == 0 || !r)  get_from_left = true;
                 else if (compare(l,r) <= 0) get_from_left = true;
                 
-                
                 if (get_from_left) {
                     e = l; l = l->next; lsize--;
                 } else {

--- a/peg-highlight/pmh_styleparser.c
+++ b/peg-highlight/pmh_styleparser.c
@@ -82,12 +82,12 @@ static void free_raw_attributes(raw_attribute *list)
     raw_attribute *cur = list;
     while (cur != NULL)
 	{
-		raw_attribute *pattr = NULL;
+        raw_attribute *pattr = NULL;
         if (cur->name != NULL) free(cur->name);
         if (cur->value != NULL) free(cur->value);
         pattr = cur;
         cur = cur->next;
-		free(pattr);
+        free(pattr);
     }
 }
 
@@ -95,7 +95,7 @@ static void free_raw_attributes(raw_attribute *list)
 static void report_error(style_parser_data *p_data,
                          int line_number, char *str, ...)
 {
-	va_list argptr;
+    va_list argptr;
     if (p_data->error_callback == NULL)
         return;
     
@@ -257,9 +257,9 @@ static void free_style_attributes(pmh_style_attribute *list)
                 free(cur->value->string);
             free(cur->value);
         }
-		pmh_style_attribute *pattr = cur;
+        pmh_style_attribute *pattr = cur;
         cur = cur->next;
-		free(pattr);
+        free(pattr);
     }
 }
 
@@ -359,8 +359,8 @@ static void free_multi_value(multi_value *val)
     {
         multi_value *pvalue = cur;
         multi_value *next_cur = cur->next;
-		free(pvalue->value);
-		free(pvalue);
+        free(pvalue->value);
+        free(pvalue);
         cur = next_cur;
     }
 }
@@ -563,9 +563,9 @@ static void free_blocks(block *val)
     while (cur != NULL)
     {
         block *pblock = cur;
-		block *next = pblock->next;
-		free_multi_value(pblock->lines);
-		free(pblock);
+        block *next = pblock->next;
+        free_multi_value(pblock->lines);
+        free(pblock);
         cur = next;
     }
 }
@@ -801,8 +801,8 @@ static void _sty_parse(style_parser_data *p_data)
     block *block_cur = blocks;
     while (block_cur != NULL)
 	{
-		raw_attribute *attributes_head = NULL;
-		raw_attribute *attributes_tail = NULL;
+        raw_attribute *attributes_head = NULL;
+        raw_attribute *attributes_tail = NULL;
 	
         pmhsp_PRINTF("Block:\n");
         multi_value *header_line = block_cur->lines;

--- a/peg-highlight/pmh_styleparser.c
+++ b/peg-highlight/pmh_styleparser.c
@@ -803,6 +803,7 @@ static void _sty_parse(style_parser_data *p_data)
 	{
 		raw_attribute *attributes_head = NULL;
 		raw_attribute *attributes_tail = NULL;
+	
         pmhsp_PRINTF("Block:\n");
         multi_value *header_line = block_cur->lines;
         if (header_line == NULL) {
@@ -820,8 +821,6 @@ static void _sty_parse(style_parser_data *p_data)
             report_error(p_data, header_line->line_number,
                          "No style attributes defined for style rule '%s'",
                          style_rule_name);
-        
-        
         
         while (attr_line_cur != NULL)
         {

--- a/peg-highlight/pmh_styleparser.c
+++ b/peg-highlight/pmh_styleparser.c
@@ -81,12 +81,13 @@ static void free_raw_attributes(raw_attribute *list)
 {
     raw_attribute *cur = list;
     while (cur != NULL)
-    {
+	{
+		raw_attribute *pattr = NULL;
         if (cur->name != NULL) free(cur->name);
         if (cur->value != NULL) free(cur->value);
-        raw_attribute *this = cur;
+        pattr = cur;
         cur = cur->next;
-        free(this);
+		free(pattr);
     }
 }
 
@@ -94,9 +95,10 @@ static void free_raw_attributes(raw_attribute *list)
 static void report_error(style_parser_data *p_data,
                          int line_number, char *str, ...)
 {
+	va_list argptr;
     if (p_data->error_callback == NULL)
         return;
-    va_list argptr;
+    
     va_start(argptr, str);
     char *errmsg;
     our_vasprintf(&errmsg, str, argptr);
@@ -255,9 +257,9 @@ static void free_style_attributes(pmh_style_attribute *list)
                 free(cur->value->string);
             free(cur->value);
         }
-        pmh_style_attribute *this = cur;
+		pmh_style_attribute *pattr = cur;
         cur = cur->next;
-        free(this);
+		free(pattr);
     }
 }
 
@@ -355,10 +357,10 @@ static void free_multi_value(multi_value *val)
     multi_value *cur = val;
     while (cur != NULL)
     {
-        multi_value *this = cur;
+        multi_value *pvalue = cur;
         multi_value *next_cur = cur->next;
-        free(this->value);
-        free(this);
+		free(pvalue->value);
+		free(pvalue);
         cur = next_cur;
     }
 }
@@ -560,10 +562,10 @@ static void free_blocks(block *val)
     block *cur = val;
     while (cur != NULL)
     {
-        block *this = cur;
-        block *next = this->next;
-        free_multi_value(this->lines);
-        free(this);
+        block *pblock = cur;
+		block *next = pblock->next;
+		free_multi_value(pblock->lines);
+		free(pblock);
         cur = next;
     }
 }
@@ -798,7 +800,9 @@ static void _sty_parse(style_parser_data *p_data)
     
     block *block_cur = blocks;
     while (block_cur != NULL)
-    {
+	{
+		raw_attribute *attributes_head = NULL;
+		raw_attribute *attributes_tail = NULL;
         pmhsp_PRINTF("Block:\n");
         multi_value *header_line = block_cur->lines;
         if (header_line == NULL) {
@@ -817,8 +821,7 @@ static void _sty_parse(style_parser_data *p_data)
                          "No style attributes defined for style rule '%s'",
                          style_rule_name);
         
-        raw_attribute *attributes_head = NULL;
-        raw_attribute *attributes_tail = NULL;
+        
         
         while (attr_line_cur != NULL)
         {

--- a/peg-highlight/pmh_styleparser.c
+++ b/peg-highlight/pmh_styleparser.c
@@ -81,7 +81,7 @@ static void free_raw_attributes(raw_attribute *list)
 {
     raw_attribute *cur = list;
     while (cur != NULL)
-	{
+    {
         raw_attribute *pattr = NULL;
         if (cur->name != NULL) free(cur->name);
         if (cur->value != NULL) free(cur->value);
@@ -800,7 +800,7 @@ static void _sty_parse(style_parser_data *p_data)
     
     block *block_cur = blocks;
     while (block_cur != NULL)
-	{
+    {
         raw_attribute *attributes_head = NULL;
         raw_attribute *attributes_tail = NULL;
 	

--- a/src/src.pro
+++ b/src/src.pro
@@ -129,6 +129,9 @@ macx {
     LIBS += -L/usr/local/lib
     INCLUDEPATH += /usr/local/include
 }
+windows {
+    DEFINES *= Q_COMPILER_INITIALIZER_LISTS
+}
 
 win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../hoedown/release/ -lhoedown
 else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../hoedown/debug/ -lhoedown

--- a/src/src.pro
+++ b/src/src.pro
@@ -129,6 +129,7 @@ macx {
     LIBS += -L/usr/local/lib
     INCLUDEPATH += /usr/local/include
 }
+
 windows {
     DEFINES *= Q_COMPILER_INITIALIZER_LISTS
 }


### PR DESCRIPTION
MSVC2013 has "initializer-list” convert to “QVector<QPair<QString,QString>>" problem, this need a compile parameter in src.pro.
peg-highlight support to MSVC2013 that declaration variable to block header.