### PR TITLE
[fix] show the default filename in 'Export As' dialog

### DIFF
--- a/src/vexporter.cpp
+++ b/src/vexporter.cpp
@@ -123,7 +123,7 @@ void VExporter::handleBrowseBtnClicked()
                        tr("Portable Document Format (*.pdf)") :
                        tr("WebPage, Complete (*.html)");
     QString path = QFileDialog::getSaveFileName(this, tr("Export As"),
-                                                fi.absolutePath(),
+                                                fi.absoluteFilePath(),
                                                 fileType);
     if (path.isEmpty()) {
         return;


### PR DESCRIPTION
Very simple fix, currently in "Export As" dialog, the default filename is missing, it's a little inconvenient. So fix it.