### PR TITLE
[function] Support to remove header sequence when disable it

### DIFF
--- a/src/vmainwindow.cpp
+++ b/src/vmainwindow.cpp
@@ -1974,9 +1974,11 @@ void VMainWindow::updateActionsStateFromTab(const VEditTab *p_tab)
     setActionsEnabled(m_editToolBar, file && editMode);
 
     // Handle heading sequence act independently.
-    m_headingSequenceAct->setEnabled(isHeadingSequenceApplicable());
+    m_headingSequenceAct->setEnabled(editMode && file->isModifiable()
+                                     && isHeadingSequenceApplicable());
     const VMdTab *mdTab = dynamic_cast<const VMdTab *>(p_tab);
-    m_headingSequenceAct->setChecked(mdTab && mdTab->isHeadingSequenceEnabled());
+    m_headingSequenceAct->setChecked(mdTab && editMode && file->isModifiable()
+                                     && mdTab->isHeadingSequenceEnabled());
 
     // Find/Replace
     m_findReplaceAct->setEnabled(file);

--- a/src/vmdeditor.cpp
+++ b/src/vmdeditor.cpp
@@ -425,7 +425,8 @@ static QString headerSequenceStr(const QVector<int> &p_sequence)
     return res;
 }
 
-static void insertSequenceToHeader(QTextBlock p_block,
+static void insertSequenceToHeader(QTextCursor& p_cursor,
+                                   QTextBlock p_block,
                                    QRegExp &p_reg,
                                    QRegExp &p_preReg,
                                    const QString &p_seq)
@@ -446,16 +447,16 @@ static void insertSequenceToHeader(QTextBlock p_block,
 
     Q_ASSERT(start <= end);
 
-    QTextCursor cursor(p_block);
-    cursor.setPosition(p_block.position() + start);
+
+    p_cursor.setPosition(p_block.position() + start);
     if (start != end) {
-        cursor.setPosition(p_block.position() + end, QTextCursor::KeepAnchor);
+        p_cursor.setPosition(p_block.position() + end, QTextCursor::KeepAnchor);
     }
 
     if (p_seq.isEmpty()) {
-        cursor.removeSelectedText();
+        p_cursor.removeSelectedText();
     } else {
-        cursor.insertText(p_seq + ' ');
+        p_cursor.insertText(p_seq + ' ');
     }
 }
 
@@ -585,7 +586,8 @@ void VMdEditor::updateHeadersHelper(const QVector<VElementRegion> &p_headerRegio
             QString seqStr = headerSequenceStr(seqs);
             if (headerSequences[i] != seqStr) {
                 // Insert correct sequence.
-                insertSequenceToHeader(doc->findBlockByNumber(headerBlockNumbers[i]),
+                insertSequenceToHeader(cursor,
+                                       doc->findBlockByNumber(headerBlockNumbers[i]),
                                        headerReg,
                                        preReg,
                                        seqStr);

--- a/src/vmdeditor.h
+++ b/src/vmdeditor.h
@@ -76,6 +76,8 @@ public:
 
     VPreviewManager *getPreviewManager() const;
 
+    void updateHeaderSequenceByConfigChange();
+
 public slots:
     bool jumpTitle(bool p_forward, int p_relativeLevel, int p_repeat) Q_DECL_OVERRIDE;
 
@@ -228,6 +230,8 @@ private slots:
     void handleCopyAsAction(QAction *p_act);
 
 private:
+
+    void updateHeadersHelper(const QVector<VElementRegion> &p_headerRegions, bool configChanged);
     // Update the config of VTextEdit according to global configurations.
     void updateTextEditConfig();
 

--- a/src/vmdeditor.h
+++ b/src/vmdeditor.h
@@ -230,8 +230,8 @@ private slots:
     void handleCopyAsAction(QAction *p_act);
 
 private:
+    void updateHeadersHelper(const QVector<VElementRegion> &p_headerRegions, bool p_configChanged);
 
-    void updateHeadersHelper(const QVector<VElementRegion> &p_headerRegions, bool configChanged);
     // Update the config of VTextEdit according to global configurations.
     void updateTextEditConfig();
 

--- a/src/vmdtab.cpp
+++ b/src/vmdtab.cpp
@@ -911,6 +911,9 @@ void VMdTab::enableHeadingSequence(bool p_enabled)
     if (m_editor) {
         VEditConfig &config = m_editor->getConfig();
         config.m_enableHeadingSequence = m_enableHeadingSequence;
+        if (isEditMode()) {
+            m_editor->updateHeaderSequenceByConfigChange();
+        }
     }
 }
 


### PR DESCRIPTION
### Specification
In edit mode:
- when click icon to enable auto sequence, add sequence immediately
- when click icon to disable auto sequence, remove already added sequence

In preview/read mode:
- auto sequence icon should be unchecked and disabled

### Additional improvement
The auto-sequence should not ruin the undo history.

 All the header sequence auto-update should be treated as one edit action,
so that user can discard auto-update by pressing undo shortkey twice.
 (One for the auto-update change, and one for the original header change)