### PR TITLE
VSearchEngine: avoid virtual functions in detor

### DIFF
--- a/src/vsearchengine.cpp
+++ b/src/vsearchengine.cpp
@@ -151,8 +151,14 @@ VSearchEngine::VSearchEngine(QObject *p_parent)
 
 VSearchEngine::~VSearchEngine()
 {
-    stop();
-    clear();
+    for (auto const & th : m_workers) {
+        th->stop();
+        th->quit();
+        th->wait();
+        delete th;
+    }
+    m_workers.clear();
+    m_result.clear();
 }
 
 void VSearchEngine::search(const QSharedPointer<VSearchConfig> &p_config,


### PR DESCRIPTION
Clang-tidy checker warns followings. Here is a patch to avoid virttual functions in detor.

```
Call to virtual function during destruction
[clang-analyzer-optin.cplusplus.VirtualCall]
  stop();
  clear();
note: This destructor of an object of type '~VSearchEngine'
has not returned when the virtual method was called
```

Signed-off-by: Hiroshi Miura <miurahr@linux.com>