### PR TITLE
Make clang-tidy code checker happy

### DIFF
--- a/src/lineeditdelegate.cpp
+++ b/src/lineeditdelegate.cpp
@@ -15,7 +15,7 @@ QWidget *LineEditDelegate::createEditor(QWidget *p_parent,
     Q_UNUSED(p_option);
     Q_UNUSED(p_index);
 
-    VLineEdit *edit = new VLineEdit(p_parent);
+    auto edit = new VLineEdit(p_parent);
     return edit;
 }
 
@@ -23,7 +23,7 @@ void LineEditDelegate::setEditorData(QWidget *p_editor, const QModelIndex &p_ind
 {
     QString text = p_index.model()->data(p_index, Qt::EditRole).toString();
 
-    VLineEdit *edit = static_cast<VLineEdit *>(p_editor);
+    auto edit = static_cast<VLineEdit *>(p_editor);
     edit->setText(text);
 }
 
@@ -31,7 +31,7 @@ void LineEditDelegate::setModelData(QWidget *p_editor,
                                     QAbstractItemModel *p_model,
                                     const QModelIndex &p_index) const
 {
-    VLineEdit *edit = static_cast<VLineEdit *>(p_editor);
+    auto edit = static_cast<VLineEdit *>(p_editor);
 
     p_model->setData(p_index, edit->text(), Qt::EditRole);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
     QApplication app(argc, argv);
 
     // The file path passed via command line arguments.
-    QStringList filePaths = VUtils::filterFilePathsToOpen(app.arguments().mid(1));
+    QStringList filePaths = VUtils::filterFilePathsToOpen(QApplication::arguments().mid(1));
 
     if (!canRun) {
         // Ask another instance to open files passed in.
@@ -196,7 +196,7 @@ int main(int argc, char *argv[])
 
     qInstallMessageHandler(VLogger);
 
-    qInfo() << "VNote started" << g_config->c_version << QDateTime::currentDateTime().toString();
+    qInfo() << "VNote started" << VConfigManager::c_version << QDateTime::currentDateTime().toString();
 
     QString locale = VUtils::getLocale();
     // Set default locale.

--- a/src/peghighlighterresult.cpp
+++ b/src/peghighlighterresult.cpp
@@ -83,7 +83,7 @@ void PegHighlighterResult::parseBlocksHighlights(QVector<QVector<HLUnit>> &p_blo
     {
         const HighlightingStyle &style = styles[i];
         pmh_element *elem_cursor = pmhResult[style.type];
-        while (elem_cursor != NULL)
+        while (elem_cursor != nullptr)
         {
             // elem_cursor->pos and elem_cursor->end is the start
             // and end position of the element in document.
@@ -102,9 +102,9 @@ void PegHighlighterResult::parseBlocksHighlights(QVector<QVector<HLUnit>> &p_blo
     }
 
     // Sort p_blocksHighlights.
-    for (int i = 0; i < p_blocksHighlights.size(); ++i) {
-        if (p_blocksHighlights[i].size() > 1) {
-            std::sort(p_blocksHighlights[i].begin(), p_blocksHighlights[i].end(), compHLUnit);
+    for (auto &p_blocksHighlight : p_blocksHighlights) {
+        if (p_blocksHighlight.size() > 1) {
+            std::sort(p_blocksHighlight.begin(), p_blocksHighlight.end(), compHLUnit);
         }
     }
 }
@@ -117,7 +117,7 @@ void PegHighlighterResult::parseBlocksHighlightOne(QVector<QVector<HLUnit>> &p_b
 {
     // When the the highlight element is at the end of document, @p_end will equals
     // to the characterCount.
-    unsigned int nrChar = (unsigned int)p_doc->characterCount();
+    auto nrChar = (unsigned int)p_doc->characterCount();
     if (p_end >= nrChar && nrChar > 0) {
         p_end = nrChar - 1;
     }
@@ -280,8 +280,7 @@ void PegHighlighterResult::parseTableBlocks(const QSharedPointer<PegParseResult>
 
     VTableBlock item;
     int headerIdx = 0, borderIdx = 0;
-    for (int tableIdx = 0; tableIdx < tableRegs.size(); ++tableIdx) {
-        const auto &reg = tableRegs[tableIdx];
+    for (auto reg : tableRegs) {
         if (headerIdx < headerRegs.size()) {
             if (reg.contains(headerRegs[headerIdx])) {
                 // A new table.
@@ -333,12 +332,9 @@ void PegHighlighterResult::parseTableBlocks(const QSharedPointer<PegParseResult>
 
 static inline bool isDisplayFormulaRawEnd(const QString &p_text)
 {
-    QRegExp regex("\\\\end\\{[^{}\\s\\r\\n]+\\}$");
-    if (p_text.indexOf(regex) > -1) {
-        return true;
-    }
+    QRegExp regex(R"(\\end\{[^{}\s\r\n]+\}$)");
+    return p_text.indexOf(regex) > -1;
 
-    return false;
 }
 
 void PegHighlighterResult::parseMathjaxBlocks(const PegMarkdownHighlighter *p_peg,
@@ -349,8 +345,7 @@ void PegHighlighterResult::parseMathjaxBlocks(const PegMarkdownHighlighter *p_pe
     // Inline equations.
     const QVector<VElementRegion> &inlineRegs = p_result->m_inlineEquationRegions;
 
-    for (auto it = inlineRegs.begin(); it != inlineRegs.end(); ++it) {
-        const VElementRegion &r = *it;
+    for (auto r : inlineRegs) {
         QTextBlock block = doc->findBlock(r.m_startPos);
         if (!block.isValid()) {
             continue;
@@ -377,8 +372,7 @@ void PegHighlighterResult::parseMathjaxBlocks(const PegMarkdownHighlighter *p_pe
     bool inBlock = false;
     QString marker("$$");
     QString rawMarkerStart("\\begin{");
-    for (auto it = formulaRegs.begin(); it != formulaRegs.end(); ++it) {
-        const VElementRegion &r = *it;
+    for (auto r : formulaRegs) {
         QTextBlock block = doc->findBlock(r.m_startPos);
         int lastBlock = doc->findBlock(r.m_endPos - 1).blockNumber();
         if (lastBlock >= p_result->m_numOfBlocks) {
@@ -438,9 +432,9 @@ void PegHighlighterResult::parseHRuleBlocks(const PegMarkdownHighlighter *p_peg,
     const QTextDocument *doc = p_peg->getDocument();
     const QVector<VElementRegion> &regs = p_result->m_hruleRegions;
 
-    for (auto it = regs.begin(); it != regs.end(); ++it) {
-        QTextBlock block = doc->findBlock(it->m_startPos);
-        int lastBlock = doc->findBlock(it->m_endPos - 1).blockNumber();
+    for (auto reg : regs) {
+        QTextBlock block = doc->findBlock(reg.m_startPos);
+        int lastBlock = doc->findBlock(reg.m_endPos - 1).blockNumber();
         if (lastBlock >= p_result->m_numOfBlocks) {
             lastBlock = p_result->m_numOfBlocks - 1;
         }

--- a/src/pegmarkdownhighlighter.cpp
+++ b/src/pegmarkdownhighlighter.cpp
@@ -20,7 +20,7 @@ PegMarkdownHighlighter::PegMarkdownHighlighter(QTextDocument *p_doc, VMdEditor *
       m_editor(p_editor),
       m_timeStamp(0),
       m_codeBlockTimeStamp(0),
-      m_parser(NULL),
+      m_parser(nullptr),
       m_parserExts(pmh_EXT_NOTES
                    | pmh_EXT_STRIKE
                    | pmh_EXT_FRONTMATTER
@@ -47,10 +47,10 @@ void PegMarkdownHighlighter::init(const QVector<HighlightingStyle> &p_styles,
     m_parseInterval = p_timerInterval;
 
     m_codeBlockFormat.setForeground(QBrush(Qt::darkYellow));
-    for (int index = 0; index < m_styles.size(); ++index) {
-        switch (m_styles[index].type) {
+    for (auto &m_style : m_styles) {
+        switch (m_style.type) {
         case pmh_FENCEDCODEBLOCK:
-            m_codeBlockFormat = m_styles[index].format;
+            m_codeBlockFormat = m_style.format;
             break;
 
         default:
@@ -122,7 +122,7 @@ void PegMarkdownHighlighter::highlightBlock(const QString &p_text)
     int blockNum = block.blockNumber();
 
     bool isCodeBlock = currentBlockState() == HighlightBlockState::CodeBlock;
-    bool isNewBlock = block.userData() == NULL;
+    bool isNewBlock = block.userData() == nullptr;
     VTextBlockData *blockData = VTextBlockData::blockData(block);
     QVector<HLUnit> *cache = &blockData->getBlockHighlightCache();
 
@@ -158,7 +158,7 @@ void PegMarkdownHighlighter::highlightBlock(const QString &p_text)
                                                blockNum,
                                                p_text,
                                                isCodeBlock)) {
-                highlightBlockOne(m_fastResult->m_blocksHighlights, blockNum, NULL);
+                highlightBlockOne(m_fastResult->m_blocksHighlights, blockNum, nullptr);
             }
 
             cacheValid = false;
@@ -604,7 +604,7 @@ void PegMarkdownHighlighter::updateAllBlocksUserState(const QSharedPointer<PegHi
 
         // Set code block indentation.
         if (hlColumn) {
-            VTextBlockData *blockData = static_cast<VTextBlockData *>(block.userData());
+            auto blockData = static_cast<VTextBlockData *>(block.userData());
             Q_ASSERT(blockData);
 
             switch (it.value()) {

--- a/src/pegparser.cpp
+++ b/src/pegparser.cpp
@@ -50,9 +50,9 @@ void PegParseResult::parseHeaderRegions(QAtomicInt &p_stop)
     }
 
     pmh_element_type hx[6] = {pmh_H1, pmh_H2, pmh_H3, pmh_H4, pmh_H5, pmh_H6};
-    for (int i = 0; i < 6; ++i) {
-        pmh_element *elem = m_pmhElements[hx[i]];
-        while (elem != NULL) {
+    for (auto &i : hx) {
+        pmh_element *elem = m_pmhElements[i];
+        while (elem != nullptr) {
             if (elem->end <= elem->pos) {
                 elem = elem->next;
                 continue;
@@ -82,7 +82,7 @@ void PegParseResult::parseFencedCodeBlockRegions(QAtomicInt &p_stop)
     }
 
     pmh_element *elem = m_pmhElements[pmh_FENCEDCODEBLOCK];
-    while (elem != NULL) {
+    while (elem != nullptr) {
         if (elem->end <= elem->pos) {
             elem = elem->next;
             continue;
@@ -160,7 +160,7 @@ void PegParseResult::parseRegions(QAtomicInt &p_stop,
     }
 
     pmh_element *elem = m_pmhElements[p_type];
-    while (elem != NULL) {
+    while (elem != nullptr) {
         if (elem->end <= elem->pos) {
             elem = elem->next;
             continue;
@@ -254,7 +254,7 @@ PegParser::PegParser(QObject *p_parent)
 void PegParser::init()
 {
     for (int i = 0; i < NUM_OF_THREADS; ++i) {
-        PegParserWorker *th = new PegParserWorker(this);
+        auto *th = new PegParserWorker(this);
         connect(th, &PegParserWorker::finished,
                 this, [this, th]() {
                     handleWorkerFinished(th);
@@ -374,7 +374,7 @@ QVector<VElementRegion> PegParser::parseImageRegions(const QSharedPointer<PegPar
 
     int offset = p_config->m_offset;
     pmh_element *elem = res[pmh_IMAGE];
-    while (elem != NULL) {
+    while (elem != nullptr) {
         if (elem->end <= elem->pos) {
             elem = elem->next;
             continue;
@@ -463,7 +463,7 @@ static QSharedPointer<char> tryFixUnicodeData(const char *p_data)
         int cp;
         int nr = utf8CodePoint(ch, cp);
         if (nr == -1) {
-            return NULL;
+            return nullptr;
         }
 
         if (cp > MAX_CODE_POINT) {
@@ -478,7 +478,7 @@ static QSharedPointer<char> tryFixUnicodeData(const char *p_data)
     }
 
     if (!needFix) {
-        return NULL;
+        return nullptr;
     }
 
     // Replace those chars with two one-byte chars.
@@ -517,10 +517,10 @@ static QSharedPointer<char> tryFixUnicodeData(const char *p_data)
 pmh_element **PegParser::parseMarkdownToElements(const QSharedPointer<PegParseConfig> &p_config)
 {
     if (p_config->m_data.isEmpty()) {
-        return NULL;
+        return nullptr;
     }
 
-    pmh_element **pmhResult = NULL;
+    pmh_element **pmhResult = nullptr;
 
     // p_config->m_data is encoding in UTF-8.
     // QString stores a string of 16-bit QChars. Unicode characters with code values above 65535 are stored using surrogate pairs, i.e., two consecutive QChars.

--- a/src/valltagspanel.cpp
+++ b/src/valltagspanel.cpp
@@ -10,7 +10,7 @@ VAllTagsPanel::VAllTagsPanel(QWidget *p_parent)
 {
     m_list = new QListWidget(this);
 
-    QVBoxLayout *layout = new QVBoxLayout();
+    auto layout = new QVBoxLayout();
     layout->addWidget(m_list);
 
     setLayout(layout);
@@ -25,7 +25,7 @@ void VAllTagsPanel::clear()
 
 void VAllTagsPanel::removeItem(QListWidgetItem *p_item)
 {
-    QWidget *wid = m_list->itemWidget(p_item);
+    auto *wid = m_list->itemWidget(p_item);
     m_list->removeItemWidget(p_item);
     wid->deleteLater();
 
@@ -37,11 +37,11 @@ void VAllTagsPanel::removeItem(QListWidgetItem *p_item)
 
 VTagLabel *VAllTagsPanel::addTag(const QString &p_text)
 {
-    VTagLabel *label = new VTagLabel(p_text, true, this);
+    auto label = new VTagLabel(p_text, true, this);
     QSize sz = label->sizeHint();
     sz.setHeight(sz.height() * 2 + 10);
 
-    QListWidgetItem *item = new QListWidgetItem();
+    auto item = new QListWidgetItem();
     item->setSizeHint(sz);
 
     connect(label, &VTagLabel::removalRequested,

--- a/src/vattachmentlist.cpp
+++ b/src/vattachmentlist.cpp
@@ -22,7 +22,7 @@ VAttachmentList::VAttachmentList(QWidget *p_parent)
     : QWidget(p_parent),
       VButtonPopupWidget(this),
       m_initialized(false),
-      m_file(NULL)
+      m_file(nullptr)
 {
 }
 
@@ -44,15 +44,15 @@ void VAttachmentList::setupUI()
                     int ret = VUtils::showMessage(QMessageBox::Warning, tr("Warning"),
                                                   tr("Are you sure to clear attachments of note "
                                                      "<span style=\"%1\">%2</span>?")
-                                                    .arg(g_config->c_dataTextStyle)
+                                                    .arg(VConfigManager::c_dataTextStyle)
                                                     .arg(m_file->getName()),
                                                   tr("<span style=\"%1\">WARNING</span>: "
                                                      "VNote will delete all the files in directory "
                                                      "<span style=\"%2\">%3</span>."
                                                      "Deleted files could be found in the recycle bin "
                                                      "of this note.<br>The operation is IRREVERSIBLE!")
-                                                    .arg(g_config->c_warningTextStyle)
-                                                    .arg(g_config->c_dataTextStyle)
+                                                    .arg(VConfigManager::c_warningTextStyle)
+                                                    .arg(VConfigManager::c_dataTextStyle)
                                                     .arg(m_file->fetchAttachmentFolderPath()),
                                                   QMessageBox::Ok | QMessageBox::Cancel,
                                                   QMessageBox::Ok,
@@ -63,7 +63,7 @@ void VAttachmentList::setupUI()
                             VUtils::showMessage(QMessageBox::Warning,
                                                 tr("Warning"),
                                                 tr("Fail to clear attachments of note <span style=\"%1\">%2</span>.")
-                                                  .arg(g_config->c_dataTextStyle)
+                                                  .arg(VConfigManager::c_dataTextStyle)
                                                   .arg(m_file->getName()),
                                                 tr("Please check the attachments folder and "
                                                    "maintain the configuration file manually."),
@@ -92,7 +92,7 @@ void VAttachmentList::setupUI()
 
     m_numLabel = new QLabel();
 
-    QHBoxLayout *btnLayout = new QHBoxLayout;
+    auto *btnLayout = new QHBoxLayout;
     btnLayout->addWidget(m_addBtn);
     btnLayout->addWidget(m_clearBtn);
     btnLayout->addWidget(m_locateBtn);
@@ -112,7 +112,7 @@ void VAttachmentList::setupUI()
     connect(m_attachmentList->itemDelegate(), &QAbstractItemDelegate::commitData,
             this, &VAttachmentList::handleListItemCommitData);
 
-    QVBoxLayout *mainLayout = new QVBoxLayout();
+    auto *mainLayout = new QVBoxLayout();
     mainLayout->addLayout(btnLayout);
     mainLayout->addWidget(m_attachmentList);
 
@@ -130,20 +130,20 @@ void VAttachmentList::setFile(VNoteFile *p_file)
 
 void VAttachmentList::updateContent()
 {
-    bool enableAdd = true, enableDelete = true, enableClear = true, enableLocate = true;
+    bool enableAdd = true, enableClear = true, enableLocate = true;
     m_attachmentList->clear();
 
     if (!m_file) {
-        enableAdd = enableDelete = enableClear = enableLocate = false;
+        enableAdd = enableClear = enableLocate = false;
     } else {
         QString folder = m_file->getAttachmentFolder();
         const QVector<VAttachment> &attas = m_file->getAttachments();
 
         if (folder.isEmpty()) {
             Q_ASSERT(attas.isEmpty());
-            enableDelete = enableClear = enableLocate = false;
+            enableClear = enableLocate = false;
         } else if (attas.isEmpty()) {
-            enableDelete = enableClear = false;
+            enableClear = false;
         } else {
             fillAttachmentList(attas);
         }
@@ -169,9 +169,8 @@ void VAttachmentList::updateContent()
 void VAttachmentList::fillAttachmentList(const QVector<VAttachment> &p_attachments)
 {
     Q_ASSERT(m_attachmentList->count() == 0);
-    for (int i = 0; i < p_attachments.size(); ++i) {
-        const VAttachment &atta = p_attachments[i];
-        QListWidgetItem *item = new QListWidgetItem(atta.m_name);
+    for (const auto &atta : p_attachments) {
+        auto *item = new QListWidgetItem(atta.m_name);
         item->setFlags(item->flags() | Qt::ItemIsEditable);
         item->setData(Qt::UserRole, atta.m_name);
 
@@ -207,13 +206,13 @@ void VAttachmentList::addAttachments(const QStringList &p_files)
 {
     Q_ASSERT(m_file);
     int addedFiles = 0;
-    for (int i = 0; i < p_files.size(); ++i) {
-        if (!m_file->addAttachment(p_files[i])) {
+    for (const auto &p_file: p_files) {
+        if (!m_file->addAttachment(p_file)) {
             VUtils::showMessage(QMessageBox::Warning,
                                 tr("Warning"),
                                 tr("Fail to add attachment %1 for note <span style=\"%2\">%3</span>.")
-                                  .arg(p_files[i])
-                                  .arg(g_config->c_dataTextStyle)
+                                  .arg(p_file)
+                                  .arg(VConfigManager::c_dataTextStyle)
                                   .arg(m_file->getName()),
                                 "",
                                 QMessageBox::Ok,
@@ -249,7 +248,7 @@ void VAttachmentList::handleContextMenuRequested(QPoint p_pos)
         }
 
         if (selectedSize == 1) {
-            QAction *openAct = new QAction(tr("&Open"), &menu);
+            auto openAct = new QAction(tr("&Open"), &menu);
             openAct->setToolTip(tr("Open current attachment file"));
             connect(openAct, &QAction::triggered,
                     this, [this]() {
@@ -259,9 +258,9 @@ void VAttachmentList::handleContextMenuRequested(QPoint p_pos)
             menu.addAction(openAct);
         }
 
-        QAction *deleteAct = new QAction(VIconUtils::menuDangerIcon(":/resources/icons/delete_attachment.svg"),
-                                         tr("&Delete"),
-                                         &menu);
+        auto deleteAct = new QAction(VIconUtils::menuDangerIcon(":/resources/icons/delete_attachment.svg"),
+                                     tr("&Delete"),
+                                     &menu);
         deleteAct->setToolTip(tr("Delete selected attachments"));
         connect(deleteAct, &QAction::triggered,
                 this, &VAttachmentList::deleteSelectedItems);
@@ -275,9 +274,9 @@ void VAttachmentList::handleContextMenuRequested(QPoint p_pos)
             menu.addSeparator();
         }
 
-        QAction *sortAct = new QAction(VIconUtils::menuIcon(":/resources/icons/sort.svg"),
-                                       tr("&Sort"),
-                                       &menu);
+        auto sortAct = new QAction(VIconUtils::menuIcon(":/resources/icons/sort.svg"),
+                                   tr("&Sort"),
+                                   &menu);
         sortAct->setToolTip(tr("Sort attachments manually"));
         connect(sortAct, &QAction::triggered,
                 this, &VAttachmentList::sortItems);
@@ -331,12 +330,12 @@ void VAttachmentList::deleteSelectedItems()
         items.push_back(ConfirmItemInfo(item->text(),
                                         item->text(),
                                         "",
-                                        NULL));
+                                        nullptr));
     }
 
     QString text = tr("Are you sure to delete these attachments of note "
                       "<span style=\"%1\">%2</span>?")
-                     .arg(g_config->c_dataTextStyle).arg(m_file->getName());
+                     .arg(VConfigManager::c_dataTextStyle).arg(m_file->getName());
 
     QString info = tr("Deleted files could be found in the recycle "
                       "bin of this note.<br>"
@@ -362,7 +361,7 @@ void VAttachmentList::deleteSelectedItems()
             VUtils::showMessage(QMessageBox::Warning,
                                 tr("Warning"),
                                 tr("Fail to delete attachments of note <span style=\"%1\">%2</span>.")
-                                  .arg(g_config->c_dataTextStyle)
+                                  .arg(VConfigManager::c_dataTextStyle)
                                   .arg(m_file->getName()),
                                 tr("Please check the attachments folder and "
                                    "maintain the configuration file manually."),
@@ -387,7 +386,7 @@ void VAttachmentList::sortItems()
     VSortDialog dialog(tr("Sort Attachments"),
                        tr("Sort attachments of note <span style=\"%1\">%2</span> "
                           "in the configuration file.")
-                         .arg(g_config->c_dataTextStyle)
+                         .arg(VConfigManager::c_dataTextStyle)
                          .arg(m_file->getName()),
                        g_mainWin);
     QTreeWidget *tree = dialog.getTreeWidget();
@@ -415,7 +414,7 @@ void VAttachmentList::sortItems()
             VUtils::showMessage(QMessageBox::Warning,
                                 tr("Warning"),
                                 tr("Fail to sort attachments of note <span style=\"%1\">%2</span>.")
-                                  .arg(g_config->c_dataTextStyle)
+                                  .arg(VConfigManager::c_dataTextStyle)
                                   .arg(m_file->getName()),
                                 "",
                                 QMessageBox::Ok,
@@ -463,7 +462,7 @@ void VAttachmentList::handleListItemCommitData(QWidget *p_itemEdit)
             VUtils::showMessage(QMessageBox::Warning,
                                 tr("Rename Attachment"),
                                 tr("Fail to rename attachment <span style=\"%1\">%2</span>.")
-                                  .arg(g_config->c_dataTextStyle)
+                                  .arg(VConfigManager::c_dataTextStyle)
                                   .arg(oldText),
                                 "",
                                 QMessageBox::Ok,
@@ -521,10 +520,10 @@ bool VAttachmentList::handleDropEvent(QDropEvent *p_event)
         // Add attachments.
         QStringList files;
         QList<QUrl> urls = mime->urls();
-        for (int i = 0; i < urls.size(); ++i) {
+        for (auto &url : urls) {
             QString file;
-            if (urls[i].isLocalFile()) {
-                file = urls[i].toLocalFile();
+            if (url.isLocalFile()) {
+                file = url.toLocalFile();
                 QFileInfo fi(file);
                 if (fi.exists() && fi.isFile()) {
                     file = QDir::cleanPath(fi.absoluteFilePath());
@@ -590,13 +589,13 @@ void VAttachmentList::checkAttachments()
         items.push_back(ConfirmItemInfo(atta,
                                         atta,
                                         "",
-                                        NULL));
+                                        nullptr));
     }
 
     QString text = tr("VNote detects that these attachments of note "
                       "<span style=\"%1\">%2</span> are missing in disk. "
                       "Would you like to remove them from the note?")
-                     .arg(g_config->c_dataTextStyle)
+                     .arg(VConfigManager::c_dataTextStyle)
                      .arg(m_file->getName());
 
     QString info = tr("Click \"Cancel\" to leave them untouched.");
@@ -621,7 +620,7 @@ void VAttachmentList::checkAttachments()
             VUtils::showMessage(QMessageBox::Warning,
                                 tr("Warning"),
                                 tr("Fail to delete attachments of note <span style=\"%1\">%2</span>.")
-                                  .arg(g_config->c_dataTextStyle)
+                                  .arg(VConfigManager::c_dataTextStyle)
                                   .arg(m_file->getName()),
                                 tr("Please check the attachments folder and "
                                    "maintain the configuration file manually."),
@@ -675,11 +674,7 @@ void VAttachmentList::attachmentInfo()
                                              tr("Rename attachment (%1):").arg(oldName),
                                              oldName,
                                              [this](const QString &p_name) {
-                                                if (m_file->findAttachment(p_name, false) > -1) {
-                                                    return true;
-                                                }
-
-                                                return false;
+                                                 return m_file->findAttachment(p_name, false) > -1;
                                              },
                                              g_mainWin);
 
@@ -691,7 +686,7 @@ void VAttachmentList::attachmentInfo()
         VUtils::showMessage(QMessageBox::Warning,
                             tr("Attachment Information"),
                             tr("Fail to rename attachment <span style=\"%1\">%2</span>.")
-                              .arg(g_config->c_dataTextStyle)
+                              .arg(VConfigManager::c_dataTextStyle)
                               .arg(oldName),
                             "",
                             QMessageBox::Ok,

--- a/src/vcaptain.cpp
+++ b/src/vcaptain.cpp
@@ -15,7 +15,7 @@ extern VConfigManager *g_config;
 VCaptain::VCaptain(QWidget *p_parent)
     : QWidget(p_parent),
       m_mode(CaptainMode::Normal),
-      m_widgetBeforeCaptain(NULL),
+      m_widgetBeforeCaptain(nullptr),
       m_nextMajorKey('a'),
       m_ignoreFocusChange(false)
 {
@@ -107,7 +107,7 @@ void VCaptain::keyPressEvent(QKeyEvent *p_event)
 
 bool VCaptain::handleKeyPress(int p_key, Qt::KeyboardModifiers p_modifiers)
 {
-    bool ret = true;
+    bool ret;
 
     m_ignoreFocusChange = true;
 
@@ -142,7 +142,7 @@ bool VCaptain::handleKeyPressNavigationMode(int p_key,
                 hasConsumed = true;
                 if (succeed) {
                     // Exit.
-                    m_widgetBeforeCaptain = NULL;
+                    m_widgetBeforeCaptain = nullptr;
                 } else {
                     // Consumed but not succeed. Need more keys.
                     pending = true;
@@ -187,7 +187,7 @@ void VCaptain::restoreFocus()
 {
     if (m_widgetBeforeCaptain) {
         m_widgetBeforeCaptain->setFocus();
-        m_widgetBeforeCaptain = NULL;
+        m_widgetBeforeCaptain = nullptr;
     }
 }
 
@@ -246,14 +246,14 @@ void VCaptain::triggerCaptainTarget(const QString &p_key)
 
     CaptainData data(m_widgetBeforeCaptain);
     if (!target.m_function(target.m_target, (void *)&data)) {
-        m_widgetBeforeCaptain = NULL;
+        m_widgetBeforeCaptain = nullptr;
     }
 }
 
 bool VCaptain::navigationModeByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VCaptain *obj = static_cast<VCaptain *>(p_target);
+    auto *obj = static_cast<VCaptain *>(p_target);
     obj->triggerNavigationMode();
     return true;
 }

--- a/src/vcart.cpp
+++ b/src/vcart.cpp
@@ -52,7 +52,7 @@ void VCart::setupUI()
 
     m_numLabel = new QLabel();
 
-    QHBoxLayout *btnLayout = new QHBoxLayout;
+    auto *btnLayout = new QHBoxLayout;
     btnLayout->addWidget(m_clearBtn);
     btnLayout->addStretch();
     btnLayout->addWidget(m_numLabel);
@@ -68,7 +68,7 @@ void VCart::setupUI()
     connect(m_itemList, &QListWidget::itemActivated,
             this, &VCart::openItem);
 
-    QVBoxLayout *mainLayout = new QVBoxLayout();
+    auto *mainLayout = new QVBoxLayout();
     mainLayout->addLayout(btnLayout);
     mainLayout->addWidget(m_itemList);
     mainLayout->setContentsMargins(3, 0, 3, 0);

--- a/src/vdirectorytree.cpp
+++ b/src/vdirectorytree.cpp
@@ -23,7 +23,7 @@ extern VNote *g_vnote;
 VDirectoryTree::VDirectoryTree(QWidget *parent)
     : VTreeWidget(parent),
       VNavigationMode(),
-      m_editArea(NULL)
+      m_editArea(nullptr)
 {
     setColumnCount(1);
     setHeaderHidden(true);
@@ -77,7 +77,7 @@ void VDirectoryTree::initShortcuts()
 
     QKeySequence seq = QKeySequence(g_config->getShortcutKeySequence("NewSubfolder"));
     if (!seq.isEmpty()) {
-        QShortcut *newSubDirShortcut = new QShortcut(seq, this);
+        auto *newSubDirShortcut = new QShortcut(seq, this);
         newSubDirShortcut->setContext(Qt::ApplicationShortcut);
         connect(newSubDirShortcut, &QShortcut::activated,
                 this, [this](){
@@ -134,12 +134,9 @@ void VDirectoryTree::updateDirectoryTree()
 
     VDirectory *rootDir = m_notebook->getRootDir();
     const QVector<VDirectory *> &subDirs = rootDir->getSubDirs();
-    for (int i = 0; i < subDirs.size(); ++i) {
-        VDirectory *dir = subDirs[i];
-        QTreeWidgetItem *item = new QTreeWidgetItem(this);
-
+    for (auto dir : subDirs) {
+        auto *item = new QTreeWidgetItem(this);
         fillTreeItem(item, dir);
-
         buildSubTree(item, 1);
     }
 
@@ -196,9 +193,8 @@ void VDirectoryTree::buildSubTree(QTreeWidgetItem *p_parent, int p_depth)
         }
     } else {
         const QVector<VDirectory *> &subDirs = dir->getSubDirs();
-        for (int i = 0; i < subDirs.size(); ++i) {
-            VDirectory *subDir = subDirs[i];
-            QTreeWidgetItem *item = new QTreeWidgetItem(p_parent);
+        for (auto subDir : subDirs) {
+            auto *item = new QTreeWidgetItem(p_parent);
             fillTreeItem(item, subDir);
             buildSubTree(item, p_depth - 1);
         }
@@ -265,7 +261,7 @@ void VDirectoryTree::updateItemDirectChildren(QTreeWidgetItem *p_item)
 
     for (int i = 0; i < dirs.size(); ++i) {
         VDirectory *dir = dirs[i];
-        QTreeWidgetItem *item = itemDirMap.value(dir, NULL);
+        QTreeWidgetItem *item = itemDirMap.value(dir, nullptr);
         if (item) {
             if (p_item) {
                 p_item->removeChild(item);
@@ -527,7 +523,7 @@ void VDirectoryTree::newRootDirectory()
             return;
         }
 
-        updateItemDirectChildren(NULL);
+        updateItemDirectChildren(nullptr);
 
         locateDirectory(dir);
     }
@@ -595,7 +591,7 @@ void VDirectoryTree::deleteSelectedDirectory()
 void VDirectoryTree::currentDirectoryItemChanged(QTreeWidgetItem *currentItem)
 {
     if (!currentItem) {
-        emit currentDirectoryChanged(NULL);
+        emit currentDirectoryChanged(nullptr);
         return;
     }
 
@@ -660,7 +656,7 @@ void VDirectoryTree::reloadFromDisk()
 
     QString msg;
     QString info;
-    VDirectory *curDir = NULL;
+    VDirectory *curDir = nullptr;
     QTreeWidgetItem *curItem = currentItem();
     if (curItem) {
         // Reload current directory.
@@ -705,7 +701,7 @@ void VDirectoryTree::reloadFromDisk()
             return;
         }
 
-        setCurrentItem(NULL);
+        setCurrentItem(nullptr);
 
         curItem->setExpanded(false);
         curDir->setExpanded(false);
@@ -714,8 +710,8 @@ void VDirectoryTree::reloadFromDisk()
 
         // Remove all its children.
         QList<QTreeWidgetItem *> children = curItem->takeChildren();
-        for (int i = 0; i < children.size(); ++i) {
-            delete children[i];
+        for  (auto child : children) {
+            delete child;
         }
 
         buildSubTree(curItem, 1);
@@ -755,8 +751,8 @@ void VDirectoryTree::copySelectedDirectories(bool p_isCut)
     }
 
     QJsonArray dirs;
-    for (int i = 0; i < items.size(); ++i) {
-        VDirectory *dir = getVDirectory(items[i]);
+    for (auto & item : items) {
+        VDirectory *dir = getVDirectory(item);
         dirs.append(dir->fetchPath());
     }
 
@@ -820,15 +816,15 @@ void VDirectoryTree::pasteDirectories(VDirectory *p_destDir,
     }
 
     int nrPasted = 0;
-    for (int i = 0; i < p_dirs.size(); ++i) {
-        VDirectory *dir = g_vnote->getInternalDirectory(p_dirs[i]);
+    for (const auto & p_dir : p_dirs) {
+        VDirectory *dir = g_vnote->getInternalDirectory(p_dir);
         if (!dir) {
-            qWarning() << "Copied dir is not an internal folder" << p_dirs[i];
+            qWarning() << "Copied dir is not an internal folder" << p_dir;
             VUtils::showMessage(QMessageBox::Warning,
                                 tr("Warning"),
                                 tr("Fail to paste folder <span style=\"%1\">%2</span>.")
                                   .arg(g_config->c_dataTextStyle)
-                                  .arg(p_dirs[i]),
+                                  .arg(p_dir),
                                 tr("VNote could not find this folder in any notebook."),
                                 QMessageBox::Ok,
                                 QMessageBox::Ok,
@@ -857,7 +853,7 @@ void VDirectoryTree::pasteDirectories(VDirectory *p_destDir,
         }
 
         QString msg;
-        VDirectory *destDir = NULL;
+        VDirectory *destDir = nullptr;
         bool ret = VDirectory::copyDirectory(p_destDir,
                                              dirName,
                                              dir,
@@ -869,7 +865,7 @@ void VDirectoryTree::pasteDirectories(VDirectory *p_destDir,
                                 tr("Warning"),
                                 tr("Fail to copy folder <span style=\"%1\">%2</span>.")
                                   .arg(g_config->c_dataTextStyle)
-                                  .arg(p_dirs[i]),
+                                  .arg(p_dir),
                                 msg,
                                 QMessageBox::Ok,
                                 QMessageBox::Ok,
@@ -943,7 +939,7 @@ void VDirectoryTree::mousePressEvent(QMouseEvent *event)
 {
     QTreeWidgetItem *item = itemAt(event->pos());
     if (!item) {
-        setCurrentItem(NULL);
+        setCurrentItem(nullptr);
     }
 
     VTreeWidget::mousePressEvent(event);
@@ -993,14 +989,14 @@ QTreeWidgetItem *VDirectoryTree::findVDirectory(const VDirectory *p_dir, bool *p
     }
 
     if (!p_dir) {
-        return NULL;
+        return nullptr;
     } else if (p_dir->getNotebookName() != m_notebook->getName()) {
-        return NULL;
+        return nullptr;
     } else if (p_dir == m_notebook->getRootDir()) {
         if (p_widget) {
             *p_widget = true;
         }
-        return NULL;
+        return nullptr;
     }
 
     bool isWidget;
@@ -1025,7 +1021,7 @@ QTreeWidgetItem *VDirectoryTree::findVDirectory(const VDirectory *p_dir, bool *p
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 bool VDirectoryTree::locateDirectory(const VDirectory *p_directory)
@@ -1051,7 +1047,7 @@ QTreeWidgetItem *VDirectoryTree::expandToVDirectory(const VDirectory *p_director
     if (!p_directory
         || p_directory->getNotebook() != m_notebook
         || p_directory == m_notebook->getRootDir()) {
-        return NULL;
+        return nullptr;
     }
 
     if (p_directory->getParentDirectory() == m_notebook->getRootDir()) {
@@ -1066,7 +1062,7 @@ QTreeWidgetItem *VDirectoryTree::expandToVDirectory(const VDirectory *p_director
     } else {
         QTreeWidgetItem *pItem = expandToVDirectory(p_directory->getParentDirectory());
         if (!pItem) {
-            return NULL;
+            return nullptr;
         }
 
         int nrChild = pItem->childCount();
@@ -1083,7 +1079,7 @@ QTreeWidgetItem *VDirectoryTree::expandToVDirectory(const VDirectory *p_director
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 void VDirectoryTree::expandSubTree(QTreeWidgetItem *p_item)
@@ -1158,7 +1154,7 @@ void VDirectoryTree::sortItems(VDirectory *p_dir)
         return;
     }
 
-    bool isNotebook = p_dir->parent() == NULL;
+    bool isNotebook = p_dir->parent() == nullptr;
 
     VSortDialog dialog(tr("Sort Folders"),
                        tr("Sort folders in %1 <span style=\"%2\">%3</span> "
@@ -1167,7 +1163,7 @@ void VDirectoryTree::sortItems(VDirectory *p_dir)
                          .arg(g_config->c_dataTextStyle)
                          .arg(isNotebook ? p_dir->getNotebook()->getName() : p_dir->getName()),
                        this);
-    QTreeWidget *tree = dialog.getTreeWidget();
+    auto *tree = dialog.getTreeWidget();
     tree->clear();
     tree->setColumnCount(2);
     QStringList headers;
@@ -1180,7 +1176,7 @@ void VDirectoryTree::sortItems(VDirectory *p_dir)
         QString createdTime = VUtils::displayDateTime(dir->getCreatedTimeUtc().toLocalTime(), true);
         QStringList cols;
         cols << dir->getName() << createdTime;
-        QTreeWidgetItem *item = new QTreeWidgetItem(tree, cols);
+        auto *item = new QTreeWidgetItem(tree, cols);
 
         item->setData(0, Qt::UserRole, i);
     }
@@ -1220,7 +1216,7 @@ VDirectory *VDirectoryTree::currentDirectory() const
         return getVDirectory(item);
     }
 
-    return NULL;
+    return nullptr;
 }
 
 void VDirectoryTree::pinDirectoryToHistory()

--- a/src/veditarea.cpp
+++ b/src/veditarea.cpp
@@ -37,7 +37,7 @@ VEditArea::VEditArea(QWidget *parent)
 
     initShortcuts();
 
-    QTimer *timer = new QTimer(this);
+    auto *timer = new QTimer(this);
     timer->setSingleShot(false);
     timer->setInterval(g_config->getFileTimerInterval());
     connect(timer, &QTimer::timeout,
@@ -63,7 +63,7 @@ void VEditArea::setupUI()
     m_findReplace->setOption(FindOption::IncrementalSearch,
                              g_config->getFindIncrementalSearch());
 
-    QVBoxLayout *mainLayout = new QVBoxLayout();
+    auto *mainLayout = new QVBoxLayout();
     mainLayout->addWidget(splitter);
     mainLayout->addWidget(m_findReplace);
     mainLayout->setContentsMargins(0, 0, 0, 0);
@@ -153,7 +153,7 @@ void VEditArea::initShortcuts()
 
 void VEditArea::insertSplitWindow(int idx)
 {
-    VEditWindow *win = new VEditWindow(this);
+    auto *win = new VEditWindow(this);
     splitter->insertWidget(idx, win);
     connect(win, &VEditWindow::tabStatusUpdated,
             this, &VEditArea::handleWindowTabStatusUpdated);
@@ -202,7 +202,7 @@ void VEditArea::removeSplitWindow(VEditWindow *win)
 
     win->hide();
     win->setParent(this);
-    disconnect(win, 0, this, 0);
+    disconnect(win, nullptr, this, nullptr);
     // Should be deleted later
     win->deleteLater();
 }
@@ -210,7 +210,7 @@ void VEditArea::removeSplitWindow(VEditWindow *win)
 VEditTab *VEditArea::openFile(VFile *p_file, OpenFileMode p_mode, bool p_forceMode)
 {
     if (!p_file) {
-        return NULL;
+        return nullptr;
     }
 
     // Update auto save settings.
@@ -220,7 +220,7 @@ VEditTab *VEditArea::openFile(VFile *p_file, OpenFileMode p_mode, bool p_forceMo
     if (p_file->getDocType() == DocType::Unknown) {
         QUrl url = QUrl::fromLocalFile(p_file->fetchPath());
         QDesktopServices::openUrl(url);
-        return NULL;
+        return nullptr;
     }
 
     // Find if it has been opened already
@@ -232,10 +232,10 @@ VEditTab *VEditArea::openFile(VFile *p_file, OpenFileMode p_mode, bool p_forceMo
         // Current window first
         winIdx = tabs[0].first;
         tabIdx = tabs[0].second;
-        for (int i = 0; i < tabs.size(); ++i) {
-            if (tabs[i].first == curWindowIndex) {
-                winIdx = tabs[i].first;
-                tabIdx = tabs[i].second;
+        for (auto &tab : tabs) {
+            if (tab.first == curWindowIndex) {
+                winIdx = tab.first;
+                tabIdx = tab.second;
                 break;
             }
         }
@@ -582,7 +582,7 @@ void VEditArea::handleNotebookUpdated(const VNotebook *p_notebook)
 VEditTab *VEditArea::getCurrentTab() const
 {
     if (curWindowIndex == -1) {
-        return NULL;
+        return nullptr;
     }
 
     VEditWindow *win = getWindow(curWindowIndex);
@@ -593,7 +593,7 @@ VEditTab *VEditArea::getTab(int p_winIdx, int p_tabIdx) const
 {
     VEditWindow *win = getWindow(p_winIdx);
     if (!win) {
-        return NULL;
+        return nullptr;
     }
 
     return win->getTab(p_tabIdx);
@@ -763,7 +763,7 @@ void VEditArea::moveCurrentTabOneSplit(bool p_right)
 VEditWindow *VEditArea::getCurrentWindow() const
 {
     if (curWindowIndex < 0) {
-        return NULL;
+        return nullptr;
     }
 
     return getWindow(curWindowIndex);
@@ -847,7 +847,7 @@ bool VEditArea::handleKeyNavigation(int p_key, bool &p_succeed)
 
 int VEditArea::openFiles(const QVector<VFileSessionInfo> &p_files, bool p_oneByOne)
 {
-    VFile *curFile = NULL;
+    VFile *curFile = nullptr;
     int nrOpened = 0;
     for (auto const & info : p_files) {
         QString filePath = VUtils::validFilePathToOpen(info.m_file);
@@ -1000,7 +1000,7 @@ void VEditArea::registerCaptainTargets()
 bool VEditArea::activateTabByCaptain(void *p_target, void *p_data, int p_idx)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
     VEditWindow *win = obj->getCurrentWindow();
     if (win) {
         if (win->activateTab(p_idx)) {
@@ -1014,7 +1014,7 @@ bool VEditArea::activateTabByCaptain(void *p_target, void *p_data, int p_idx)
 bool VEditArea::alternateTabByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
     VEditWindow *win = obj->getCurrentWindow();
     if (win) {
         if (win->alternateTab()) {
@@ -1028,7 +1028,7 @@ bool VEditArea::alternateTabByCaptain(void *p_target, void *p_data)
 bool VEditArea::showOpenedFileListByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
     VEditWindow *win = obj->getCurrentWindow();
     if (win) {
         if (win->showOpenedFileList()) {
@@ -1042,7 +1042,7 @@ bool VEditArea::showOpenedFileListByCaptain(void *p_target, void *p_data)
 bool VEditArea::activateSplitLeftByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
     if (obj->focusNextWindow(-1) > -1) {
         return false;
     }
@@ -1053,7 +1053,7 @@ bool VEditArea::activateSplitLeftByCaptain(void *p_target, void *p_data)
 bool VEditArea::activateSplitRightByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
     if (obj->focusNextWindow(1) > -1) {
         return false;
     }
@@ -1064,7 +1064,7 @@ bool VEditArea::activateSplitRightByCaptain(void *p_target, void *p_data)
 bool VEditArea::moveTabSplitLeftByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
     obj->moveCurrentTabOneSplit(false);
     return true;
 }
@@ -1072,7 +1072,7 @@ bool VEditArea::moveTabSplitLeftByCaptain(void *p_target, void *p_data)
 bool VEditArea::moveTabSplitRightByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
     obj->moveCurrentTabOneSplit(true);
     return true;
 }
@@ -1080,7 +1080,7 @@ bool VEditArea::moveTabSplitRightByCaptain(void *p_target, void *p_data)
 bool VEditArea::activateNextTabByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
     VEditWindow *win = obj->getCurrentWindow();
     if (win) {
         win->focusNextTab(true);
@@ -1093,7 +1093,7 @@ bool VEditArea::activateNextTabByCaptain(void *p_target, void *p_data)
 bool VEditArea::activatePreviousTabByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
     VEditWindow *win = obj->getCurrentWindow();
     if (win) {
         win->focusNextTab(false);
@@ -1106,7 +1106,7 @@ bool VEditArea::activatePreviousTabByCaptain(void *p_target, void *p_data)
 bool VEditArea::verticalSplitByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
     obj->splitCurrentWindow();
     return false;
 }
@@ -1114,7 +1114,7 @@ bool VEditArea::verticalSplitByCaptain(void *p_target, void *p_data)
 bool VEditArea::removeSplitByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
     obj->removeCurrentWindow();
 
     QWidget *nextFocus = obj->getCurrentTab();
@@ -1130,7 +1130,7 @@ bool VEditArea::removeSplitByCaptain(void *p_target, void *p_data)
 bool VEditArea::maximizeSplitByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
 
     obj->maximizeCurrentSplit();
     return true;
@@ -1139,7 +1139,7 @@ bool VEditArea::maximizeSplitByCaptain(void *p_target, void *p_data)
 bool VEditArea::distributeSplitsByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
 
     obj->distributeSplits();
     return true;
@@ -1147,8 +1147,8 @@ bool VEditArea::distributeSplitsByCaptain(void *p_target, void *p_data)
 
 bool VEditArea::evaluateMagicWordsByCaptain(void *p_target, void *p_data)
 {
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
-    CaptainData *data = static_cast<CaptainData *>(p_data);
+    auto *obj = static_cast<VEditArea *>(p_target);
+    auto *data = static_cast<CaptainData *>(p_data);
 
     VEditTab *tab = obj->getCurrentTab();
     if (tab
@@ -1162,8 +1162,8 @@ bool VEditArea::evaluateMagicWordsByCaptain(void *p_target, void *p_data)
 
 bool VEditArea::applySnippetByCaptain(void *p_target, void *p_data)
 {
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
-    CaptainData *data = static_cast<CaptainData *>(p_data);
+    auto *obj = static_cast<VEditArea *>(p_target);
+    auto *data = static_cast<CaptainData *>(p_data);
 
     VEditTab *tab = obj->getCurrentTab();
     if (tab
@@ -1178,9 +1178,9 @@ bool VEditArea::applySnippetByCaptain(void *p_target, void *p_data)
 bool VEditArea::toggleLivePreviewByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
 
-    VMdTab *tab = dynamic_cast<VMdTab *>(obj->getCurrentTab());
+    auto *tab = dynamic_cast<VMdTab *>(obj->getCurrentTab());
     if (tab) {
         if (tab->toggleLivePreview()) {
             return false;
@@ -1193,9 +1193,9 @@ bool VEditArea::toggleLivePreviewByCaptain(void *p_target, void *p_data)
 bool VEditArea::expandLivePreviewByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
 
-    VMdTab *tab = dynamic_cast<VMdTab *>(obj->getCurrentTab());
+    auto *tab = dynamic_cast<VMdTab *>(obj->getCurrentTab());
     if (tab) {
         if (tab->expandRestorePreviewArea()) {
             return false;
@@ -1208,9 +1208,9 @@ bool VEditArea::expandLivePreviewByCaptain(void *p_target, void *p_data)
 bool VEditArea::parseAndPasteByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VEditArea *obj = static_cast<VEditArea *>(p_target);
+    auto *obj = static_cast<VEditArea *>(p_target);
 
-    const VMdTab *tab = dynamic_cast<const VMdTab *>(obj->getCurrentTab());
+    const auto *tab = dynamic_cast<const VMdTab *>(obj->getCurrentTab());
     if (tab && tab->isEditMode()) {
         VMdEditor *editor = tab->getEditor();
         editor->parseAndPaste();
@@ -1302,8 +1302,8 @@ void VEditArea::distributeSplits()
         return;
     }
 
-    for (int i = 0; i < sizes.size(); ++i) {
-        sizes[i] = newWidth;
+    for (int &size : sizes) {
+        size = newWidth;
     }
 
     splitter->setSizes(sizes);

--- a/src/veditwindow.cpp
+++ b/src/veditwindow.cpp
@@ -29,11 +29,11 @@ extern VNote *g_vnote;
 VEditWindow::VEditWindow(VEditArea *editArea, QWidget *parent)
     : QTabWidget(parent),
       m_editArea(editArea),
-      m_curTabWidget(NULL),
-      m_lastTabWidget(NULL),
-      m_removeSplitAct(NULL),
-      m_maximizeSplitAct(NULL),
-      m_distributeSplitsAct(NULL)
+      m_curTabWidget(nullptr),
+      m_lastTabWidget(nullptr),
+      m_removeSplitAct(nullptr),
+      m_maximizeSplitAct(nullptr),
+      m_distributeSplitsAct(nullptr)
 {
     setAcceptDrops(true);
     setupCornerWidget();
@@ -84,7 +84,7 @@ void VEditWindow::setupCornerWidget()
         leftBtn->setToolTip(QString("%1\t%2").arg(leftBtn->toolTip()).arg(keyText));
     }
 
-    VOpenedListMenu *leftMenu = new VOpenedListMenu(this);
+    auto *leftMenu = new VOpenedListMenu(this);
     leftMenu->setToolTipsVisible(true);
     connect(leftMenu, &VOpenedListMenu::fileTriggered,
             this, &VEditWindow::tabListJump);
@@ -95,7 +95,7 @@ void VEditWindow::setupCornerWidget()
                                "", this);
     rightBtn->setProperty("CornerBtn", true);
     rightBtn->setToolTip(tr("Menu"));
-    QMenu *rightMenu = new QMenu(this);
+    auto *rightMenu = new QMenu(this);
     rightMenu->setToolTipsVisible(true);
     rightBtn->setMenu(rightMenu);
     connect(rightMenu, &QMenu::aboutToShow,
@@ -104,8 +104,8 @@ void VEditWindow::setupCornerWidget()
             });
 
     // Move all buttons to the right corner.
-    QWidget *widget = new QWidget(this);
-    QHBoxLayout *layout = new QHBoxLayout();
+    auto widget = new QWidget(this);
+    auto *layout = new QHBoxLayout();
     layout->addWidget(leftBtn);
     layout->addWidget(rightBtn);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -272,7 +272,7 @@ bool VEditWindow::closeAllFiles(bool p_forced)
 
 int VEditWindow::openFileInTab(VFile *p_file, OpenFileMode p_mode)
 {
-    VEditTab *editor = NULL;
+    VEditTab *editor = nullptr;
     switch (p_file->getDocType()) {
     case DocType::Markdown:
         editor = new VMdTab(p_file, m_editArea, p_mode, this);
@@ -524,10 +524,10 @@ void VEditWindow::tabbarContextMenuRequested(QPoint p_pos)
 
                 QString folderPath;
                 if (file->getType() == FileType::Note) {
-                    const VNoteFile *tmpFile = static_cast<const VNoteFile *>((VFile *)file);
+                    const auto *tmpFile = static_cast<const VNoteFile *>((VFile *)file);
                     folderPath = tmpFile->getNotebook()->getRecycleBinFolderPath();
                 } else if (file->getType() == FileType::Orphan) {
-                    const VOrphanFile *tmpFile = static_cast<const VOrphanFile *>((VFile *)file);
+                    const auto *tmpFile = static_cast<const VOrphanFile *>((VFile *)file);
                     folderPath = tmpFile->fetchRecycleBinFolderPath();
                 } else {
                     Q_ASSERT(false);
@@ -628,7 +628,7 @@ void VEditWindow::tabbarContextMenuRequested(QPoint p_pos)
                 QPointer<VFile> file = editor->getFile();
                 Q_ASSERT(file);
                 if (file->getType() == FileType::Note) {
-                    VNoteFile *tmpFile = static_cast<VNoteFile *>((VFile *)file);
+                    auto *tmpFile = static_cast<VNoteFile *>((VFile *)file);
                     g_mainWin->getFileList()->fileInfo(tmpFile);
                 } else if (file->getType() == FileType::Orphan) {
                     g_mainWin->editOrphanFileInfo(file);
@@ -852,7 +852,7 @@ void VEditWindow::updateSplitMenu(QMenu *p_menu)
 
 bool VEditWindow::canRemoveSplit()
 {
-    QSplitter *splitter = dynamic_cast<QSplitter *>(parent());
+    auto *splitter = dynamic_cast<QSplitter *>(parent());
     Q_ASSERT(splitter);
     return splitter->count() > 1;
 }
@@ -974,7 +974,7 @@ VEditTab *VEditWindow::getCurrentTab() const
 {
     int idx = currentIndex();
     if (idx == -1) {
-        return NULL;
+        return nullptr;
     }
 
     return getTab(idx);
@@ -1047,7 +1047,7 @@ void VEditWindow::moveTabOneSplit(int p_tabIdx, bool p_right)
     removeTab(p_tabIdx);
 
     // Disconnect all the signals.
-    disconnect(editor, 0, this, 0);
+    disconnect(editor, nullptr, this, nullptr);
 
     m_editArea->moveTab(editor, idx, newIdx);
 
@@ -1073,7 +1073,7 @@ bool VEditWindow::addEditTab(QWidget *p_widget)
         return false;
     }
 
-    VEditTab *editor = dynamic_cast<VEditTab *>(p_widget);
+    auto *editor = dynamic_cast<VEditTab *>(p_widget);
     if (!editor) {
         return false;
     }
@@ -1155,7 +1155,7 @@ bool VEditWindow::showOpenedFileList()
     }
 
     leftBtn->showMenu();
-    VOpenedListMenu *menu = static_cast<VOpenedListMenu *>(leftBtn->menu());
+    auto *menu = static_cast<VOpenedListMenu *>(leftBtn->menu());
     return menu->isAccepted();
 }
 
@@ -1181,7 +1181,7 @@ bool VEditWindow::alternateTab()
             setCurrentWidget(m_lastTabWidget);
             return true;
         } else {
-            m_lastTabWidget = NULL;
+            m_lastTabWidget = nullptr;
         }
     }
     return false;
@@ -1287,7 +1287,7 @@ void VEditWindow::tabRequestToClose(VEditTab *p_tab)
         removeTab(indexOf(p_tab));
 
         // Disconnect all the signals.
-        disconnect(p_tab, 0, this, 0);
+        disconnect(p_tab, nullptr, this, nullptr);
 
         p_tab->deleteLater();
     }
@@ -1320,7 +1320,7 @@ QVector<TabNavigationInfo> VEditWindow::getTabsNavigationInfo() const
 bool VEditWindow::eventFilter(QObject *p_obj, QEvent *p_event)
 {
     if (p_obj == tabBar() && p_event->type() == QEvent::MouseButtonRelease) {
-        QMouseEvent *me = static_cast<QMouseEvent *>(p_event);
+        auto *me = static_cast<QMouseEvent *>(p_event);
         if (me->button() == Qt::MiddleButton) {
             // Close current tab.
             int idx = tabBar()->tabAt(me->pos());

--- a/src/vexplorer.cpp
+++ b/src/vexplorer.cpp
@@ -112,7 +112,7 @@ void VExplorer::setupUI()
                 }
             });
 
-    QHBoxLayout *dirLayout = new QHBoxLayout();
+    auto *dirLayout = new QHBoxLayout();
     dirLayout->addWidget(dirLabel);
     dirLayout->addStretch();
     dirLayout->addWidget(m_openBtn);
@@ -136,8 +136,8 @@ void VExplorer::setupUI()
                     setCurrentEntry(idx);
                 }
             });
-    QCompleter *completer = new QCompleter(this);
-    QFileSystemModel *fsModel = new QFileSystemModel(completer);
+    auto *completer = new QCompleter(this);
+    auto *fsModel = new QFileSystemModel(completer);
     fsModel->setRootPath("");
     completer->setModel(fsModel);
     // Enable styling the popup list via QListView::item.
@@ -195,13 +195,13 @@ void VExplorer::setupUI()
     connect(m_newDirBtn, &QPushButton::clicked,
             this, &VExplorer::newFolder);
 
-    QHBoxLayout *btnLayout = new QHBoxLayout();
+    auto *btnLayout = new QHBoxLayout();
     btnLayout->addStretch();
     btnLayout->addWidget(m_newFileBtn);
     btnLayout->addWidget(m_newDirBtn);
     btnLayout->setContentsMargins(0, 0, 0, 0);
 
-    QFileSystemModel *dirModel = new QFileSystemModel(this);
+    auto *dirModel = new QFileSystemModel(this);
     dirModel->setRootPath("");
     m_tree = new QTreeView(this);
     m_tree->setModel(dirModel);
@@ -211,7 +211,7 @@ void VExplorer::setupUI()
             this, &VExplorer::handleContextMenuRequested);
     connect(m_tree, &QTreeView::activated,
             this, [this](const QModelIndex &p_index) {
-                QFileSystemModel *model = static_cast<QFileSystemModel *>(m_tree->model());
+                auto *model = static_cast<QFileSystemModel *>(m_tree->model());
                 if (!model->isDir(p_index)) {
                     QStringList files;
                     files << model->filePath(p_index);
@@ -237,7 +237,7 @@ void VExplorer::setupUI()
         m_tree->hideColumn(i);
     }
 
-    QVBoxLayout *mainLayout = new QVBoxLayout();
+    auto *mainLayout = new QVBoxLayout();
     mainLayout->addLayout(dirLayout);
     mainLayout->addWidget(m_dirCB);
     mainLayout->addWidget(imgLabel);
@@ -265,7 +265,7 @@ void VExplorer::init()
             this, [this]() {
                 QModelIndexList selectedIdx = m_tree->selectionModel()->selectedRows();
                 if (selectedIdx.size() == 1) {
-                    QFileSystemModel *model = static_cast<QFileSystemModel *>(m_tree->model());
+                    auto model = static_cast<QFileSystemModel *>(m_tree->model());
                     QString filePath = model->filePath(selectedIdx[0]);
                     renameFile(filePath);
                 }
@@ -445,7 +445,7 @@ void VExplorer::updateTree()
 {
     if (checkIndex()) {
         QString pa = QDir::cleanPath(m_entries[m_index].m_directory);
-        QFileSystemModel *model = static_cast<QFileSystemModel *>(m_tree->model());
+        auto *model = static_cast<QFileSystemModel *>(m_tree->model());
         model->setRootPath(pa);
         const QModelIndex rootIndex = model->index(pa);
         if (rootIndex.isValid()) {
@@ -471,7 +471,7 @@ void VExplorer::handleContextMenuRequested(QPoint p_pos)
     QMenu menu(this);
     menu.setToolTipsVisible(true);
 
-    QFileSystemModel *model = static_cast<QFileSystemModel *>(m_tree->model());
+    auto model = static_cast<QFileSystemModel *>(m_tree->model());
     QModelIndexList selectedIdx = m_tree->selectionModel()->selectedRows();
     if (selectedIdx.size() == 1 && model->isDir(selectedIdx[0])) {
         QString filePath = model->filePath(selectedIdx[0]);
@@ -642,7 +642,7 @@ void VExplorer::newFile()
 
     QString parentDir;
 
-    QFileSystemModel *model = static_cast<QFileSystemModel *>(m_tree->model());
+    auto *model = static_cast<QFileSystemModel *>(m_tree->model());
     QModelIndexList selectedIdx = m_tree->selectionModel()->selectedRows();
     if (selectedIdx.size() == 1 && model->isDir(selectedIdx[0])) {
         parentDir = model->filePath(selectedIdx[0]);
@@ -699,7 +699,7 @@ void VExplorer::newFolder()
 
     QString parentDir;
 
-    QFileSystemModel *model = static_cast<QFileSystemModel *>(m_tree->model());
+    auto *model = static_cast<QFileSystemModel *>(m_tree->model());
     QModelIndexList selectedIdx = m_tree->selectionModel()->selectedRows();
     if (selectedIdx.size() == 1 && model->isDir(selectedIdx[0])) {
         parentDir = model->filePath(selectedIdx[0]);

--- a/src/vfilelist.cpp
+++ b/src/vfilelist.cpp
@@ -29,9 +29,9 @@ extern VMainWindow *g_mainWin;
 VFileList::VFileList(QWidget *parent)
     : QWidget(parent),
       VNavigationMode(),
-      m_openWithMenu(NULL),
-      m_itemClicked(NULL),
-      m_fileToCloseInSingleClick(NULL)
+      m_openWithMenu(nullptr),
+      m_itemClicked(nullptr),
+      m_fileToCloseInSingleClick(nullptr)
 {
     setupUI();
     initShortcuts();
@@ -43,9 +43,9 @@ VFileList::VFileList(QWidget *parent)
     // effect as opening file in current tab.
     connect(m_clickTimer, &QTimer::timeout,
             this, [this]() {
-                m_itemClicked = NULL;
+                m_itemClicked = nullptr;
                 VFile *file = m_fileToCloseInSingleClick;
-                m_fileToCloseInSingleClick = NULL;
+                m_fileToCloseInSingleClick = nullptr;
 
                 if (file) {
                     editArea->closeFile(file, false);
@@ -68,7 +68,7 @@ void VFileList::setupUI()
     viewBtn->setProperty("CornerBtn", true);
     viewBtn->setFocusPolicy(Qt::NoFocus);
 
-    QMenu *viewMenu = new QMenu(this);
+    auto *viewMenu = new QMenu(this);
     connect(viewMenu, &QMenu::aboutToShow,
             this, [this, viewMenu]() {
                 updateViewMenu(viewMenu);
@@ -89,7 +89,7 @@ void VFileList::setupUI()
 
     m_numLabel = new QLabel(this);
 
-    QHBoxLayout *titleLayout = new QHBoxLayout();
+    auto *titleLayout = new QHBoxLayout();
     titleLayout->addWidget(titleLabel);
     titleLayout->addWidget(viewBtn);
     titleLayout->addWidget(m_splitBtn);
@@ -107,7 +107,7 @@ void VFileList::setupUI()
                 return getMimeData(p_format, p_items);
             });
 
-    QVBoxLayout *mainLayout = new QVBoxLayout;
+    auto *mainLayout = new QVBoxLayout;
     mainLayout->addLayout(titleLayout);
     mainLayout->addWidget(fileList);
     mainLayout->setContentsMargins(0, 0, 0, 0);
@@ -161,7 +161,7 @@ void VFileList::initShortcuts()
 
     QKeySequence seq(g_config->getShortcutKeySequence("OpenViaDefaultProgram"));
     if (!seq.isEmpty()) {
-        QShortcut *defaultProgramShortcut = new QShortcut(seq, this);
+        auto *defaultProgramShortcut = new QShortcut(seq, this);
         defaultProgramShortcut->setContext(Qt::WidgetWithChildrenShortcut);
         connect(defaultProgramShortcut, &QShortcut::activated,
                 this, &VFileList::openCurrentItemViaDefaultProgram);
@@ -202,8 +202,7 @@ void VFileList::updateFileList()
     QVector<VNoteFile *> files = m_directory->getFiles();
     sortFiles(files, (ViewOrder)g_config->getNoteListViewOrder());
 
-    for (int i = 0; i < files.size(); ++i) {
-        VNoteFile *file = files[i];
+    for (auto file : files) {
         insertFileListItem(file);
     }
 
@@ -232,8 +231,8 @@ void VFileList::addFileToCart() const
     QList<QListWidgetItem *> items = fileList->selectedItems();
     VCart *cart = g_mainWin->getCart();
 
-    for (int i = 0; i < items.size(); ++i) {
-        cart->addFile(getVFile(items[i])->fetchPath());
+    for (auto &item : items) {
+        cart->addFile(getVFile(item)->fetchPath());
     }
 
     g_mainWin->showStatusMessage(tr("%1 %2 added to Cart")
@@ -246,8 +245,8 @@ void VFileList::pinFileToHistory() const
     QList<QListWidgetItem *> items = fileList->selectedItems();
 
     QStringList files;
-    for (int i = 0; i < items.size(); ++i) {
-        files << getVFile(items[i])->fetchPath();
+    for (auto &item : items) {
+        files << getVFile(item)->fetchPath();
     }
 
     g_mainWin->getHistoryList()->pinFiles(files);
@@ -286,7 +285,7 @@ void VFileList::fileInfo(VNoteFile *p_file)
         if (!p_file->rename(name)) {
             VUtils::showMessage(QMessageBox::Warning, tr("Warning"),
                                 tr("Fail to rename note <span style=\"%1\">%2</span>.")
-                                  .arg(g_config->c_dataTextStyle).arg(curName), "",
+                                  .arg(VConfigManager::c_dataTextStyle).arg(curName), "",
                                 QMessageBox::Ok, QMessageBox::Ok, this);
             return;
         }
@@ -302,7 +301,7 @@ void VFileList::fileInfo(VNoteFile *p_file)
 
 void VFileList::fillItem(QListWidgetItem *p_item, const VNoteFile *p_file)
 {
-    qulonglong ptr = (qulonglong)p_file;
+    auto ptr = (qulonglong)p_file;
     p_item->setData(Qt::UserRole, ptr);
     p_item->setText(p_file->getName());
 
@@ -319,7 +318,7 @@ void VFileList::fillItem(QListWidgetItem *p_item, const VNoteFile *p_file)
 QListWidgetItem* VFileList::insertFileListItem(VNoteFile *file, bool atFront)
 {
     V_ASSERT(file);
-    QListWidgetItem *item = new QListWidgetItem();
+    auto *item = new QListWidgetItem();
     fillItem(item, file);
 
     if (atFront) {
@@ -371,7 +370,7 @@ void VFileList::newFile()
     }
 
     QString info = tr("Create a note in <span style=\"%1\">%2</span>.")
-                     .arg(g_config->c_dataTextStyle).arg(m_directory->getName());
+                     .arg(VConfigManager::c_dataTextStyle).arg(m_directory->getName());
     info = info + "<br>" + tr("Note with name ending with \"%1\" will be treated as Markdown type.")
                              .arg(suffixStr);
     QString defaultName = QString("new_note.%1").arg(defaultSuf);
@@ -385,7 +384,7 @@ void VFileList::newFile()
         if (!file) {
             VUtils::showMessage(QMessageBox::Warning, tr("Warning"),
                                 tr("Fail to create note <span style=\"%1\">%2</span>.")
-                                  .arg(g_config->c_dataTextStyle).arg(dialog.getNameInput()), "",
+                                  .arg(VConfigManager::c_dataTextStyle).arg(dialog.getNameInput()), "",
                                 QMessageBox::Ok, QMessageBox::Ok, this);
             return;
         }
@@ -491,7 +490,7 @@ void VFileList::deleteFiles(const QVector<VNoteFile *> &p_files)
                       "bin of these notes.<br>"
                       "Click \"Cancel\" to leave them untouched.<br>"
                       "The operation is IRREVERSIBLE!")
-                     .arg(g_config->c_warningTextStyle);
+                     .arg(VConfigManager::c_warningTextStyle);
 
     VConfirmDeletionDialog dialog(tr("Confirm Deleting Notes"),
                                   text,
@@ -523,7 +522,7 @@ void VFileList::deleteFiles(const QVector<VNoteFile *> &p_files)
                                     tr("Warning"),
                                     tr("Fail to delete note <span style=\"%1\">%2</span>.<br>"
                                        "Please check <span style=\"%1\">%3</span> and manually delete it.")
-                                      .arg(g_config->c_dataTextStyle)
+                                      .arg(VConfigManager::c_dataTextStyle)
                                       .arg(fileName)
                                       .arg(filePath),
                                     errMsg,
@@ -721,7 +720,7 @@ void VFileList::contextMenuRequested(QPoint pos)
 QListWidgetItem* VFileList::findItem(const VNoteFile *p_file)
 {
     if (!p_file || p_file->getDirectory() != m_directory) {
-        return NULL;
+        return nullptr;
     }
 
     int nrChild = fileList->count();
@@ -732,7 +731,7 @@ QListWidgetItem* VFileList::findItem(const VNoteFile *p_file)
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 void VFileList::handleItemClicked(QListWidgetItem *p_item)
@@ -749,15 +748,15 @@ void VFileList::handleItemClicked(QListWidgetItem *p_item)
         // Timer will not trigger.
         if (m_itemClicked == p_item) {
             // Double clicked.
-            m_itemClicked = NULL;
-            m_fileToCloseInSingleClick = NULL;
+            m_itemClicked = nullptr;
+            m_fileToCloseInSingleClick = nullptr;
             return;
         } else {
             // Handle previous clicked item as single click.
-            m_itemClicked = NULL;
+            m_itemClicked = nullptr;
             if (m_fileToCloseInSingleClick) {
                 editArea->closeFile(m_fileToCloseInSingleClick, false);
-                m_fileToCloseInSingleClick = NULL;
+                m_fileToCloseInSingleClick = nullptr;
             }
         }
     }
@@ -776,14 +775,14 @@ void VFileList::handleItemClicked(QListWidgetItem *p_item)
         // EditArea will open Unknown file using system's default program, in which
         // case we should now close current file even after single click.
         if (file->getDocType() == DocType::Unknown) {
-            m_fileToCloseInSingleClick = NULL;
+            m_fileToCloseInSingleClick = nullptr;
         } else {
             // Get current tab which will be closed if click timer timeouts.
             VEditTab *tab = editArea->getCurrentTab();
             if (tab) {
                 m_fileToCloseInSingleClick = tab->getFile();
             } else {
-                m_fileToCloseInSingleClick = NULL;
+                m_fileToCloseInSingleClick = nullptr;
             }
         }
     }
@@ -818,7 +817,7 @@ void VFileList::showStatusTipAboutItem(QListWidgetItem *p_item)
 void VFileList::activateItem(QListWidgetItem *p_item, bool p_restoreFocus)
 {
     if (!p_item) {
-        emit fileClicked(NULL);
+        emit fileClicked(nullptr);
         return;
     }
 
@@ -918,8 +917,8 @@ void VFileList::copySelectedFiles(bool p_isCut)
     }
 
     QJsonArray files;
-    for (int i = 0; i < items.size(); ++i) {
-        VNoteFile *file = getVFile(items[i]);
+    for (auto &item : items) {
+        VNoteFile *file = getVFile(item);
         files.append(file->fetchPath());
     }
 
@@ -975,15 +974,15 @@ void VFileList::pasteFiles(VDirectory *p_destDir,
     }
 
     int nrPasted = 0;
-    for (int i = 0; i < p_files.size(); ++i) {
-        VNoteFile *file = g_vnote->getInternalFile(p_files[i]);
+    for (const auto &p_file : p_files) {
+        VNoteFile *file = g_vnote->getInternalFile(p_file);
         if (!file) {
-            qWarning() << "Copied file is not an internal note" << p_files[i];
+            qWarning() << "Copied file is not an internal note" << p_file;
             VUtils::showMessage(QMessageBox::Warning,
                                 tr("Warning"),
                                 tr("Fail to paste note <span style=\"%1\">%2</span>.")
-                                  .arg(g_config->c_dataTextStyle)
-                                  .arg(p_files[i]),
+                                  .arg(VConfigManager::c_dataTextStyle)
+                                  .arg(p_file),
                                 tr("VNote could not find this note in any notebook."),
                                 QMessageBox::Ok,
                                 QMessageBox::Ok,
@@ -1010,8 +1009,8 @@ void VFileList::pasteFiles(VDirectory *p_destDir,
                     VUtils::showMessage(QMessageBox::Warning,
                                         tr("Warning"),
                                         tr("Fail to copy note <span style=\"%1\">%2</span>.")
-                                          .arg(g_config->c_dataTextStyle)
-                                          .arg(p_files[i]),
+                                          .arg(VConfigManager::c_dataTextStyle)
+                                          .arg(p_file),
                                         tr("VNote does not allow copy and paste notes with internal images "
                                            "in the same folder."),
                                         QMessageBox::Ok,
@@ -1033,7 +1032,7 @@ void VFileList::pasteFiles(VDirectory *p_destDir,
         }
 
         QString msg;
-        VNoteFile *destFile = NULL;
+        VNoteFile *destFile = nullptr;
         bool ret = VNoteFile::copyFile(p_destDir,
                                        fileName,
                                        file,
@@ -1045,8 +1044,8 @@ void VFileList::pasteFiles(VDirectory *p_destDir,
             VUtils::showMessage(QMessageBox::Warning,
                                 tr("Warning"),
                                 tr("Fail to copy note <span style=\"%1\">%2</span>.")
-                                  .arg(g_config->c_dataTextStyle)
-                                  .arg(p_files[i]),
+                                  .arg(VConfigManager::c_dataTextStyle)
+                                  .arg(p_file),
                                 msg,
                                 QMessageBox::Ok,
                                 QMessageBox::Ok,
@@ -1078,7 +1077,7 @@ void VFileList::keyPressEvent(QKeyEvent *p_event)
     {
         QListWidgetItem *item = fileList->currentItem();
         if (item) {
-            VFile *fileToClose = NULL;
+            VFile *fileToClose = nullptr;
             VFile *file = getVFile(item);
             Q_ASSERT(file);
             if (p_event->modifiers() == Qt::NoModifier
@@ -1195,7 +1194,7 @@ void VFileList::sortItems()
     VSortDialog dialog(tr("Sort Notes"),
                        tr("Sort notes in folder <span style=\"%1\">%2</span> "
                           "in the configuration file.")
-                         .arg(g_config->c_dataTextStyle)
+                         .arg(VConfigManager::c_dataTextStyle)
                          .arg(m_directory->getName()),
                        this);
     QTreeWidget *tree = dialog.getTreeWidget();
@@ -1211,7 +1210,7 @@ void VFileList::sortItems()
         QString modifiedTime = VUtils::displayDateTime(file->getModifiedTimeUtc().toLocalTime(), true);
         QStringList cols;
         cols << file->getName() << createdTime << modifiedTime;
-        QTreeWidgetItem *item = new QTreeWidgetItem(tree, cols);
+        auto *item = new QTreeWidgetItem(tree, cols);
 
         item->setData(0, Qt::UserRole, i);
     }
@@ -1231,7 +1230,7 @@ void VFileList::sortItems()
             VUtils::showMessage(QMessageBox::Warning,
                                 tr("Warning"),
                                 tr("Fail to sort notes in folder <span style=\"%1\">%2</span>.")
-                                  .arg(g_config->c_dataTextStyle)
+                                  .arg(VConfigManager::c_dataTextStyle)
                                   .arg(m_directory->getName()),
                                 "",
                                 QMessageBox::Ok,
@@ -1261,13 +1260,13 @@ QMenu *VFileList::getOpenWithMenu()
                                     .arg(VUtils::getShortcutText(pa.m_shortcut));
         }
 
-        QAction *act = new QAction(name, this);
+        auto *act = new QAction(name, this);
         act->setToolTip(tr("Open current note with %1").arg(pa.m_name));
         act->setStatusTip(pa.m_cmd);
         act->setData(pa.m_cmd);
 
         if (!seq.isEmpty()) {
-            QShortcut *shortcut = new QShortcut(seq, this);
+            auto *shortcut = new QShortcut(seq, this);
             shortcut->setContext(Qt::WidgetWithChildrenShortcut);
             connect(shortcut, &QShortcut::activated,
                     this, [act](){
@@ -1287,16 +1286,16 @@ QMenu *VFileList::getOpenWithMenu()
         name = QString("%1\t%2").arg(name)
                                 .arg(VUtils::getShortcutText(g_config->getShortcutKeySequence("OpenViaDefaultProgram")));
     }
-    QAction *defaultAct = new QAction(name, this);
+    auto *defaultAct = new QAction(name, this);
     defaultAct->setToolTip(tr("Open current note with system's default program"));
     connect(defaultAct, &QAction::triggered,
             this, &VFileList::openCurrentItemViaDefaultProgram);
 
     m_openWithMenu->addAction(defaultAct);
 
-    QAction *addAct = new QAction(VIconUtils::menuIcon(":/resources/icons/add_program.svg"),
-                                  tr("Add External Program"),
-                                  this);
+    auto addAct = new QAction(VIconUtils::menuIcon(":/resources/icons/add_program.svg"),
+                              tr("Add External Program"),
+                              this);
     addAct->setToolTip(tr("Add external program"));
     connect(addAct, &QAction::triggered,
             this, [this]() {
@@ -1322,7 +1321,7 @@ QMenu *VFileList::getOpenWithMenu()
 
 void VFileList::handleOpenWithActionTriggered()
 {
-    QAction *act = static_cast<QAction *>(sender());
+    auto *act = dynamic_cast<QAction *>(sender());
     QString cmd = act->data().toString();
 
     QListWidgetItem *item = fileList->currentItem();
@@ -1333,7 +1332,7 @@ void VFileList::handleOpenWithActionTriggered()
                 || !editArea->isFileOpened(file)
                 || editArea->closeFile(file, false))) {
             cmd.replace("%0", file->fetchPath());
-            QProcess *process = new QProcess(this);
+            auto *process = new QProcess(this);
             connect(process, static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
                     process, &QProcess::deleteLater);
             process->start(cmd);
@@ -1351,9 +1350,9 @@ void VFileList::updateNumberLabel() const
 void VFileList::updateViewMenu(QMenu *p_menu)
 {
     if (p_menu->isEmpty()) {
-        QActionGroup *ag = new QActionGroup(p_menu);
+        auto *ag = new QActionGroup(p_menu);
 
-        QAction *act = new QAction(tr("View By Configuration File"), ag);
+        auto act = new QAction(tr("View By Configuration File"), ag);
         act->setCheckable(true);
         act->setData(ViewOrder::Config);
         act->setChecked(true);
@@ -1512,8 +1511,8 @@ QByteArray VFileList::getMimeData(const QString &p_format,
     Q_ASSERT(p_format ==ClipboardConfig::c_format);
 
     QJsonArray files;
-    for (int i = 0; i < p_items.size(); ++i) {
-        VNoteFile *file = getVFile(p_items[i]);
+    for (auto p_item : p_items) {
+        VNoteFile *file = getVFile(p_item);
         files.append(file->fetchPath());
     }
 

--- a/src/vhistorylist.cpp
+++ b/src/vhistorylist.cpp
@@ -60,7 +60,7 @@ void VHistoryList::setupUI()
                 }
             });
 
-    QHBoxLayout *btnLayout = new QHBoxLayout;
+    auto *btnLayout = new QHBoxLayout;
     btnLayout->addWidget(m_clearBtn);
     btnLayout->addStretch();
     btnLayout->setContentsMargins(0, 0, 0, 0);
@@ -74,7 +74,7 @@ void VHistoryList::setupUI()
     connect(m_itemList, &QListWidget::itemActivated,
             this, &VHistoryList::openItem);
 
-    QVBoxLayout *mainLayout = new QVBoxLayout();
+    auto *mainLayout = new QVBoxLayout();
     mainLayout->addLayout(btnLayout);
     mainLayout->addWidget(m_itemList);
     mainLayout->setContentsMargins(0, 0, 0, 0);
@@ -267,25 +267,25 @@ void VHistoryList::updateList()
 
     QIcon noteIcon(VIconUtils::treeViewIcon(":/resources/icons/note_item.svg"));
     QIcon folderIcon(VIconUtils::treeViewIcon(":/resources/icons/dir_item.svg"));
-    for (auto it = m_histories.cbegin(); it != m_histories.cend(); ++it) {
-        QListWidgetItem *item = new QListWidgetItem(VUtils::fileNameFromPath(it->m_file));
-        item->setToolTip(it->m_file);
-        item->setData(Qt::UserRole, (qulonglong)&(*it));
+    for (const auto &m_historie : m_histories) {
+        QListWidgetItem *item = new QListWidgetItem(VUtils::fileNameFromPath(m_historie.m_file));
+        item->setToolTip(m_historie.m_file);
+        item->setData(Qt::UserRole, (qulonglong)&m_historie);
 
-        if (it->m_isFolder) {
+        if (m_historie.m_isFolder) {
             item->setIcon(folderIcon);
         } else {
             item->setIcon(noteIcon);
         }
 
-        if (it->m_isPinned) {
+        if (m_historie.m_isPinned) {
             m_itemList->insertItem(m_itemList->row(pinItem.m_item) + 1, item);
             pinItem.m_valid = true;
             continue;
         }
 
         for (int i = 0; i < sepSize; ++i) {
-            if (it->m_date >= seps[i].m_date) {
+            if (m_historie.m_date >= seps[i].m_date) {
                 m_itemList->insertItem(m_itemList->row(seps[i].m_item) + 1, item);
                 seps[i].m_valid = true;
                 break;
@@ -494,8 +494,8 @@ void VHistoryList::addFileToCart() const
     QList<QListWidgetItem *> items = m_itemList->selectedItems();
     VCart *cart = g_mainWin->getCart();
 
-    for (int i = 0; i < items.size(); ++i) {
-        cart->addFile(getFilePath(items[i]));
+    for (auto &item : items) {
+        cart->addFile(getFilePath(item));
     }
 
     g_mainWin->showStatusMessage(tr("%1 %2 added to Cart")

--- a/src/vhtmltab.cpp
+++ b/src/vhtmltab.cpp
@@ -46,7 +46,7 @@ void VHtmlTab::setupUI()
 
     m_editor->reloadFile();
 
-    QVBoxLayout *mainLayout = new QVBoxLayout();
+    auto *mainLayout = new QVBoxLayout();
     mainLayout->addWidget(m_editor);
     mainLayout->setContentsMargins(0, 0, 0, 0);
     setLayout(mainLayout);
@@ -107,7 +107,7 @@ void VHtmlTab::readFile(bool p_discard)
         int ret = VUtils::showMessage(QMessageBox::Information,
                                       tr("Information"),
                                       tr("Note <span style=\"%1\">%2</span> has been modified.")
-                                        .arg(g_config->c_dataTextStyle).arg(m_file->getName()),
+                                        .arg(VConfigManager::c_dataTextStyle).arg(m_file->getName()),
                                       tr("Do you want to save your changes?"),
                                       modifiable ? (QMessageBox::Save
                                                     | QMessageBox::Discard
@@ -158,7 +158,7 @@ bool VHtmlTab::saveFile()
         VUtils::showMessage(QMessageBox::Warning,
                             tr("Warning"),
                             tr("Could not modify a read-only note <span style=\"%1\">%2</span>.")
-                              .arg(g_config->c_dataTextStyle).arg(filePath),
+                              .arg(VConfigManager::c_dataTextStyle).arg(filePath),
                             tr("Please save your changes to other notes manually."),
                             QMessageBox::Ok,
                             QMessageBox::Ok,
@@ -232,7 +232,6 @@ void VHtmlTab::findText(const VSearchToken &p_token,
     Q_UNUSED(p_token);
     Q_UNUSED(p_forward);
     Q_UNUSED(p_fromStart);
-    return;
 }
 
 void VHtmlTab::replaceText(const QString &p_text, uint p_options,
@@ -283,11 +282,7 @@ void VHtmlTab::requestUpdateVimStatus()
 
 bool VHtmlTab::restoreFromTabInfo(const VEditTabInfo &p_info)
 {
-    if (p_info.m_editTab != this) {
-        return false;
-    }
-
-    return true;
+    return p_info.m_editTab == this;
 }
 
 void VHtmlTab::reload()

--- a/src/vlistfolderue.cpp
+++ b/src/vlistfolderue.cpp
@@ -22,7 +22,7 @@ extern VNote *g_vnote;
 
 VListFolderUE::VListFolderUE(QObject *p_parent)
     : IUniversalEntry(p_parent),
-      m_listWidget(NULL)
+      m_listWidget(nullptr)
 {
 }
 
@@ -187,7 +187,7 @@ void VListFolderUE::addResultItem(const QSharedPointer<VSearchResultItem> &p_ite
         text = p_item->m_text;
     }
 
-    QIcon *icon = NULL;
+    QIcon *icon = nullptr;
     switch (p_item->m_type) {
     case VSearchResultItem::Note:
         icon = &m_noteIcon;
@@ -201,7 +201,7 @@ void VListFolderUE::addResultItem(const QSharedPointer<VSearchResultItem> &p_ite
         break;
     }
 
-    QListWidgetItem *item = new QListWidgetItem(*icon, text);
+    auto *item = new QListWidgetItem(*icon, text);
     item->setData(Qt::UserRole, m_data.size() - 1);
     item->setToolTip(p_item->m_path);
 

--- a/src/vlistue.cpp
+++ b/src/vlistue.cpp
@@ -24,7 +24,7 @@ extern VNote *g_vnote;
 
 VListUE::VListUE(QObject *p_parent)
     : IUniversalEntry(p_parent),
-      m_listWidget(NULL)
+      m_listWidget(nullptr)
 {
 }
 
@@ -183,7 +183,7 @@ void VListUE::addResultItem(const QSharedPointer<VSearchResultItem> &p_item)
         second = p_item->m_path;
     }
 
-    QIcon *icon = NULL;
+    QIcon *icon = nullptr;
     switch (p_item->m_type) {
     case VSearchResultItem::Note:
         icon = &m_noteIcon;

--- a/src/vlivepreviewhelper.cpp
+++ b/src/vlivepreviewhelper.cpp
@@ -31,8 +31,7 @@ extern VMainWindow *g_mainWin;
 #define INDEX_MASK 0x00ffffffUL
 
 CodeBlockPreviewInfo::CodeBlockPreviewInfo()
-{
-}
+= default;
 
 CodeBlockPreviewInfo::CodeBlockPreviewInfo(const VCodeBlock &p_cb)
     : m_codeBlock(p_cb)
@@ -47,7 +46,7 @@ void CodeBlockPreviewInfo::updateInplacePreview(const VEditor *p_editor,
 {
     QTextBlock block = p_doc->findBlockByNumber(m_codeBlock.m_endBlock);
     if (block.isValid()) {
-        VImageToPreview *preview = new VImageToPreview();
+        auto *preview = new VImageToPreview();
 
         preview->m_startPos = block.position();
         preview->m_endPos = block.position() + block.length();
@@ -86,8 +85,8 @@ VLivePreviewHelper::VLivePreviewHelper(VEditor *p_editor,
       m_cbIndex(-1),
       m_livePreviewEnabled(false),
       m_inplacePreviewEnabled(false),
-      m_graphvizHelper(NULL),
-      m_plantUMLHelper(NULL),
+      m_graphvizHelper(nullptr),
+      m_plantUMLHelper(nullptr),
       m_lastInplacePreviewSize(0),
       m_timeStamp(0),
       m_scaleFactor(VUtils::calculateScaleFactor()),
@@ -158,8 +157,7 @@ void VLivePreviewHelper::updateCodeBlocks(TimeStamp p_timeStamp, const QVector<V
     bool manualInplacePreview = m_inplacePreviewEnabled;
     m_codeBlocks.clear();
 
-    for (int i = 0; i < p_codeBlocks.size(); ++i) {
-        const VCodeBlock &vcb = p_codeBlocks[i];
+    for (const auto &vcb : p_codeBlocks) {
         bool livePreview = false, inplacePreview = false;
         checkLang(vcb.m_lang, livePreview, inplacePreview);
         if (!livePreview && !inplacePreview) {
@@ -464,8 +462,7 @@ void VLivePreviewHelper::updateInplacePreview()
 {
     QSet<int> blocks;
     QVector<QSharedPointer<VImageToPreview> > images;
-    for (int i = 0; i < m_codeBlocks.size(); ++i) {
-        CodeBlockPreviewInfo &cb = m_codeBlocks[i];
+    for (auto &cb : m_codeBlocks) {
         if (cb.inplacePreviewReady()) {
             if (!cb.inplacePreview()->m_image.isNull()) {
                 images.append(cb.inplacePreview());

--- a/src/vmainwindow.cpp
+++ b/src/vmainwindow.cpp
@@ -84,8 +84,8 @@ VMainWindow::VMainWindow(VSingleInstanceGuard *p_guard, QWidget *p_parent)
       m_guard(p_guard),
       m_windowOldState(Qt::WindowNoState),
       m_requestQuit(false),
-      m_printer(NULL),
-      m_ue(NULL)
+      m_printer(nullptr),
+      m_ue(nullptr)
 {
     qsrand(QDateTime::currentDateTime().toTime_t());
 
@@ -344,7 +344,7 @@ void VMainWindow::setupNotebookPanel()
 
     m_dirTree = new VDirectoryTree;
 
-    QVBoxLayout *naviLayout = new QVBoxLayout;
+    auto *naviLayout = new QVBoxLayout;
     naviLayout->addWidget(m_notebookSelector);
     naviLayout->addWidget(directoryLabel);
     naviLayout->addWidget(m_dirTree);
@@ -446,7 +446,7 @@ QToolBar *VMainWindow::initViewToolBar(QSize p_iconSize)
                 g_config->setMenuBarChecked(p_checked);
             });
 
-    QMenu *viewMenu = new QMenu(this);
+    auto *viewMenu = new QMenu(this);
     viewMenu->setToolTipsVisible(true);
     viewMenu->addAction(fullScreenAct);
     viewMenu->addAction(stayOnTopAct);
@@ -499,7 +499,7 @@ QToolBar *VMainWindow::initEditToolBar(QSize p_iconSize)
     connect(m_headingSequenceAct, &QAction::triggered,
             this, [this](bool p_checked){
                 if (isHeadingSequenceApplicable()) {
-                    VMdTab *tab = dynamic_cast<VMdTab *>(m_curTab.data());
+                    auto *tab = dynamic_cast<VMdTab *>(m_curTab.data());
                     Q_ASSERT(tab);
                     tab->enableHeadingSequence(p_checked);
                 }
@@ -754,7 +754,7 @@ QToolBar *VMainWindow::initFileToolBar(QSize p_iconSize)
                 m_editArea->readFile(true);
             });
 
-    updateEditReadAct(NULL);
+    updateEditReadAct(nullptr);
 
     saveNoteAct = new QAction(VIconUtils::toolButtonIcon(":/resources/icons/save_note.svg"),
                               tr("Save"), this);
@@ -1182,7 +1182,7 @@ void VMainWindow::initEditMenu()
             this, &VMainWindow::changeExpandTab);
 
     // Tab stop width.
-    QActionGroup *tabStopWidthAct = new QActionGroup(this);
+    auto *tabStopWidthAct = new QActionGroup(this);
     QAction *twoSpaceTabAct = new QAction(tr("2 Spaces"), tabStopWidthAct);
     twoSpaceTabAct->setToolTip(tr("Expand Tab to 2 spaces"));
     twoSpaceTabAct->setCheckable(true);
@@ -1512,7 +1512,7 @@ void VMainWindow::initConverterMenu(QMenu *p_menu)
     QMenu *converterMenu = p_menu->addMenu(tr("&Renderer"));
     converterMenu->setToolTipsVisible(true);
 
-    QActionGroup *converterAct = new QActionGroup(this);
+    auto *converterAct = new QActionGroup(this);
     QAction *markedAct = new QAction(tr("Marked"), converterAct);
     markedAct->setToolTip(tr("Use Marked to convert Markdown to HTML (re-open current tabs to make it work)"));
     markedAct->setCheckable(true);
@@ -1702,7 +1702,7 @@ void VMainWindow::initMarkdownExtensionMenu(QMenu *p_menu)
 
 void VMainWindow::initRenderBackgroundMenu(QMenu *menu)
 {
-    QActionGroup *renderBackgroundAct = new QActionGroup(this);
+    auto *renderBackgroundAct = new QActionGroup(this);
     connect(renderBackgroundAct, &QActionGroup::triggered,
             this, &VMainWindow::setRenderBackgroundColor);
 
@@ -1730,21 +1730,21 @@ void VMainWindow::initRenderBackgroundMenu(QMenu *menu)
     renderBgMenu->addAction(tmpAct);
 
     const QVector<VColor> &bgColors = g_config->getCustomColors();
-    for (int i = 0; i < bgColors.size(); ++i) {
-        tmpAct = new QAction(bgColors[i].m_name, renderBackgroundAct);
+    for (const auto & bgColor : bgColors) {
+        tmpAct = new QAction(bgColor.m_name, renderBackgroundAct);
         tmpAct->setToolTip(tr("Set as the background color for Markdown rendering "
                               "(re-open current tabs to make it work)"));
         tmpAct->setCheckable(true);
-        tmpAct->setData(bgColors[i].m_name);
+        tmpAct->setData(bgColor.m_name);
 
 #if !defined(Q_OS_MACOS) && !defined(Q_OS_MAC)
-        QColor color(bgColors[i].m_color);
+        QColor color(bgColor.m_color);
         QPixmap pixmap(COLOR_PIXMAP_ICON_SIZE, COLOR_PIXMAP_ICON_SIZE);
         pixmap.fill(color);
         tmpAct->setIcon(QIcon(pixmap));
 #endif
 
-        if (curBgColor == bgColors[i].m_name) {
+        if (curBgColor == bgColor.m_name) {
             tmpAct->setChecked(true);
         }
 
@@ -1775,7 +1775,7 @@ void VMainWindow::initRenderStyleMenu(QMenu *p_menu)
 
     styleMenu->addAction(addAct);
 
-    QActionGroup *ag = new QActionGroup(this);
+    auto *ag = new QActionGroup(this);
     connect(ag, &QActionGroup::triggered,
             this, [](QAction *p_action) {
                 QString data = p_action->data().toString();
@@ -1786,7 +1786,7 @@ void VMainWindow::initRenderStyleMenu(QMenu *p_menu)
     QList<QString> styles = g_config->getCssStyles();
     QString curStyle = g_config->getCssStyle();
     for (auto const &style : styles) {
-        QAction *act = new QAction(style, ag);
+        auto *act = new QAction(style, ag);
         act->setToolTip(tr("Set as the CSS style for Markdown rendering "
                            "(re-open current tabs to make it work)"));
         act->setCheckable(true);
@@ -1824,7 +1824,7 @@ void VMainWindow::initCodeBlockStyleMenu(QMenu *p_menu)
 
     styleMenu->addAction(addAct);
 
-    QActionGroup *ag = new QActionGroup(this);
+    auto ag = new QActionGroup(this);
     connect(ag, &QActionGroup::triggered,
             this, [](QAction *p_action) {
                 QString data = p_action->data().toString();
@@ -1835,7 +1835,7 @@ void VMainWindow::initCodeBlockStyleMenu(QMenu *p_menu)
     QList<QString> styles = g_config->getCodeBlockCssStyles();
     QString curStyle = g_config->getCodeBlockCssStyle();
     for (auto const &style : styles) {
-        QAction *act = new QAction(style, ag);
+        auto act = new QAction(style, ag);
         act->setToolTip(tr("Set as the code block CSS style for Markdown rendering "
                            "(re-open current tabs to make it work)"));
         act->setCheckable(true);
@@ -1855,7 +1855,7 @@ void VMainWindow::initEditorBackgroundMenu(QMenu *menu)
     QMenu *backgroundColorMenu = menu->addMenu(tr("&Background Color"));
     backgroundColorMenu->setToolTipsVisible(true);
 
-    QActionGroup *backgroundColorAct = new QActionGroup(this);
+    auto backgroundColorAct = new QActionGroup(this);
     connect(backgroundColorAct, &QActionGroup::triggered,
             this, &VMainWindow::setEditorBackgroundColor);
 
@@ -1870,20 +1870,20 @@ void VMainWindow::initEditorBackgroundMenu(QMenu *menu)
     }
     backgroundColorMenu->addAction(tmpAct);
     const QVector<VColor> &bgColors = g_config->getCustomColors();
-    for (int i = 0; i < bgColors.size(); ++i) {
-        tmpAct = new QAction(bgColors[i].m_name, backgroundColorAct);
+    for (const auto & bgColor : bgColors) {
+        tmpAct = new QAction(bgColor.m_name, backgroundColorAct);
         tmpAct->setToolTip(tr("Set as the background color for editor (re-open current tabs to make it work)"));
         tmpAct->setCheckable(true);
-        tmpAct->setData(bgColors[i].m_name);
+        tmpAct->setData(bgColor.m_name);
 
 #if !defined(Q_OS_MACOS) && !defined(Q_OS_MAC)
-        QColor color(bgColors[i].m_color);
+        QColor color(bgColor.m_color);
         QPixmap pixmap(COLOR_PIXMAP_ICON_SIZE, COLOR_PIXMAP_ICON_SIZE);
         pixmap.fill(color);
         tmpAct->setIcon(QIcon(pixmap));
 #endif
 
-        if (curBgColor == bgColors[i].m_name) {
+        if (curBgColor == bgColor.m_name) {
             tmpAct->setChecked(true);
         }
 
@@ -1896,7 +1896,7 @@ void VMainWindow::initEditorLineNumberMenu(QMenu *p_menu)
     QMenu *lineNumMenu = p_menu->addMenu(tr("Line Number"));
     lineNumMenu->setToolTipsVisible(true);
 
-    QActionGroup *lineNumAct = new QActionGroup(lineNumMenu);
+    auto lineNumAct = new QActionGroup(lineNumMenu);
     connect(lineNumAct, &QActionGroup::triggered,
             this, [this](QAction *p_action){
                 if (!p_action) {
@@ -1969,7 +1969,7 @@ void VMainWindow::initEditorStyleMenu(QMenu *p_menu)
 
     styleMenu->addAction(addAct);
 
-    QActionGroup *ag = new QActionGroup(this);
+    auto ag = new QActionGroup(this);
     connect(ag, &QActionGroup::triggered,
             this, [](QAction *p_action) {
                 QString data = p_action->data().toString();
@@ -1979,7 +1979,7 @@ void VMainWindow::initEditorStyleMenu(QMenu *p_menu)
     QList<QString> styles = g_config->getEditorStyles();
     QString style = g_config->getEditorStyle();
     for (auto const &item : styles) {
-        QAction *act = new QAction(item, ag);
+        auto act = new QAction(item, ag);
         act->setToolTip(tr("Set as the editor style (re-open current tabs to make it work)"));
         act->setCheckable(true);
         act->setData(item);
@@ -1998,7 +1998,7 @@ void VMainWindow::initAutoScrollCursorLineMenu(QMenu *p_menu)
     QMenu *subMenu = p_menu->addMenu(tr("Auto Scroll Cursor Line"));
     subMenu->setToolTipsVisible(true);
 
-    QActionGroup *ag = new QActionGroup(this);
+    auto ag = new QActionGroup(this);
     connect(ag, &QActionGroup::triggered,
             this, [](QAction *p_action) {
                 g_config->setAutoScrollCursorLine(p_action->data().toInt());
@@ -2048,7 +2048,7 @@ void VMainWindow::setRenderBackgroundColor(QAction *action)
 
 void VMainWindow::updateActionsStateFromTab(const VEditTab *p_tab)
 {
-    const VFile *file = p_tab ? p_tab->getFile() : NULL;
+    const VFile *file = p_tab ? p_tab->getFile() : nullptr;
     bool editMode = p_tab ? p_tab->isEditMode() : false;
     bool systemFile = file
                       && file->getType() == FileType::Orphan
@@ -2072,7 +2072,7 @@ void VMainWindow::updateActionsStateFromTab(const VEditTab *p_tab)
     m_headingSequenceAct->setEnabled(editMode
                                      && file->isModifiable()
                                      && isHeadingSequenceApplicable());
-    const VMdTab *mdTab = dynamic_cast<const VMdTab *>(p_tab);
+    auto mdTab = dynamic_cast<const VMdTab *>(p_tab);
     m_headingSequenceAct->setChecked(mdTab
                                      && editMode
                                      && file->isModifiable()
@@ -2102,7 +2102,7 @@ void VMainWindow::handleAreaTabStatusUpdated(const VEditTabInfo &p_info)
             }
 
             // Disconnect the trigger signal from edit tab.
-            disconnect((VEditTab *)m_curTab, 0, m_vimCmd, 0);
+            disconnect((VEditTab *)m_curTab, nullptr, m_vimCmd, nullptr);
         }
 
         m_curTab = p_info.m_editTab;
@@ -2117,7 +2117,7 @@ void VMainWindow::handleAreaTabStatusUpdated(const VEditTabInfo &p_info)
     if (m_curTab) {
         m_curFile = m_curTab->getFile();
     } else {
-        m_curFile = NULL;
+        m_curFile = nullptr;
     }
 
     if (p_info.m_type == VEditTabInfo::InfoType::All) {
@@ -2131,7 +2131,7 @@ void VMainWindow::handleAreaTabStatusUpdated(const VEditTabInfo &p_info)
                                              m_curTab->isEditMode());
 
             if (m_curFile->getType() == FileType::Note) {
-                const VNoteFile *tmpFile = dynamic_cast<const VNoteFile *>((VFile *)m_curFile);
+                auto tmpFile = dynamic_cast<const VNoteFile *>((VFile *)m_curFile);
                 title = QString("[%1] %2").arg(tmpFile->getNotebookName()).arg(tmpFile->fetchPath());
             } else {
                 title = QString("%1").arg(m_curFile->fetchPath());
@@ -2190,11 +2190,11 @@ void VMainWindow::curEditFileInfo()
     Q_ASSERT(m_curFile);
 
     if (m_curFile->getType() == FileType::Note) {
-        VNoteFile *file = dynamic_cast<VNoteFile *>((VFile *)m_curFile);
+        auto file = dynamic_cast<VNoteFile *>((VFile *)m_curFile);
         Q_ASSERT(file);
         m_fileList->fileInfo(file);
     } else if (m_curFile->getType() == FileType::Orphan) {
-        VOrphanFile *file = dynamic_cast<VOrphanFile *>((VFile *)m_curFile);
+        auto file = dynamic_cast<VOrphanFile *>((VFile *)m_curFile);
         Q_ASSERT(file);
         if (!file->isSystemFile()) {
             editOrphanFileInfo(m_curFile);
@@ -2208,7 +2208,7 @@ void VMainWindow::deleteCurNote()
         return;
     }
 
-    VNoteFile *file = dynamic_cast<VNoteFile *>((VFile *)m_curFile);
+    auto file = dynamic_cast<VNoteFile *>((VFile *)m_curFile);
     m_fileList->deleteFile(file);
 }
 
@@ -2366,7 +2366,7 @@ bool VMainWindow::locateFile(VFile *p_file)
         return ret;
     }
 
-    VNoteFile *file = dynamic_cast<VNoteFile *>(p_file);
+    auto file = dynamic_cast<VNoteFile *>(p_file);
     VNotebook *notebook = file->getNotebook();
     if (m_notebookSelector->locateNotebook(notebook)) {
         while (m_dirTree->currentNotebook() != notebook) {
@@ -2546,7 +2546,7 @@ void VMainWindow::printNote()
 
     V_ASSERT(m_curTab);
 
-    VMdTab *mdTab = dynamic_cast<VMdTab *>((VEditTab *)m_curTab);
+    auto mdTab = dynamic_cast<VMdTab *>((VEditTab *)m_curTab);
     VWebView *webView = mdTab->getWebViewer();
 
     V_ASSERT(webView);
@@ -2559,11 +2559,11 @@ void VMainWindow::printNote()
         webView->page()->print(m_printer, [this](bool p_succ) {
                     qDebug() << "print web page callback" << p_succ;
                     delete m_printer;
-                    m_printer = NULL;
+                    m_printer = nullptr;
                 });
     } else {
         delete m_printer;
-        m_printer = NULL;
+        m_printer = nullptr;
     }
 }
 
@@ -2662,7 +2662,7 @@ QVector<VFile *> VMainWindow::openFiles(const QStringList &p_files,
 
 void VMainWindow::editOrphanFileInfo(VFile *p_file)
 {
-    VOrphanFile *file = dynamic_cast<VOrphanFile *>(p_file);
+    auto file = dynamic_cast<VOrphanFile *>(p_file);
     Q_ASSERT(file);
 
     VOrphanFileInfoDialog dialog(file, this);
@@ -2691,7 +2691,7 @@ void VMainWindow::checkSharedMemory()
 
 void VMainWindow::initTrayIcon()
 {
-    QMenu *menu = new QMenu(this);
+    auto menu = new QMenu(this);
     QAction *showMainWindowAct = menu->addAction(tr("Show VNote"));
     connect(showMainWindowAct, &QAction::triggered,
             this, &VMainWindow::showMainWindow);
@@ -2723,7 +2723,7 @@ void VMainWindow::initTrayIcon()
 void VMainWindow::changeEvent(QEvent *p_event)
 {
     if (p_event->type() == QEvent::WindowStateChange) {
-        QWindowStateChangeEvent *eve = dynamic_cast<QWindowStateChangeEvent *>(p_event);
+        auto eve = dynamic_cast<QWindowStateChangeEvent *>(p_event);
         m_windowOldState = eve->oldState();
     }
 
@@ -2794,7 +2794,7 @@ bool VMainWindow::isHeadingSequenceApplicable() const
 bool VMainWindow::showAttachmentListByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VMainWindow *obj = static_cast<VMainWindow *>(p_target);
+    auto obj = static_cast<VMainWindow *>(p_target);
     if (obj->m_attachmentBtn->isEnabled()) {
         // Show tool bar first.
         bool toolBarChecked = obj->m_toolBarAct->isChecked();
@@ -2818,7 +2818,7 @@ bool VMainWindow::showAttachmentListByCaptain(void *p_target, void *p_data)
 bool VMainWindow::locateCurrentFileByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VMainWindow *obj = static_cast<VMainWindow *>(p_target);
+    auto obj = static_cast<VMainWindow *>(p_target);
     if (obj->m_curFile) {
         if (obj->locateFile(obj->m_curFile)) {
             return false;
@@ -2831,7 +2831,7 @@ bool VMainWindow::locateCurrentFileByCaptain(void *p_target, void *p_data)
 bool VMainWindow::toggleExpandModeByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VMainWindow *obj = static_cast<VMainWindow *>(p_target);
+    auto obj = static_cast<VMainWindow *>(p_target);
     obj->expandViewAct->trigger();
     return true;
 }
@@ -2839,7 +2839,7 @@ bool VMainWindow::toggleExpandModeByCaptain(void *p_target, void *p_data)
 bool VMainWindow::discardAndReadByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VMainWindow *obj = static_cast<VMainWindow *>(p_target);
+    auto obj = static_cast<VMainWindow *>(p_target);
     if (obj->m_curTab) {
         obj->m_discardExitAct->trigger();
         obj->m_curTab->setFocus();
@@ -2853,7 +2853,7 @@ bool VMainWindow::discardAndReadByCaptain(void *p_target, void *p_data)
 bool VMainWindow::toggleToolBarByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VMainWindow *obj = static_cast<VMainWindow *>(p_target);
+    auto obj = static_cast<VMainWindow *>(p_target);
     obj->m_toolBarAct->trigger();
     return true;
 }
@@ -2861,7 +2861,7 @@ bool VMainWindow::toggleToolBarByCaptain(void *p_target, void *p_data)
 bool VMainWindow::toggleToolsDockByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VMainWindow *obj = static_cast<VMainWindow *>(p_target);
+    auto obj = static_cast<VMainWindow *>(p_target);
     obj->m_toolDock->setVisible(!obj->m_toolDock->isVisible());
     return true;
 }
@@ -2869,7 +2869,7 @@ bool VMainWindow::toggleToolsDockByCaptain(void *p_target, void *p_data)
 bool VMainWindow::toggleSearchDockByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VMainWindow *obj = static_cast<VMainWindow *>(p_target);
+    auto obj = static_cast<VMainWindow *>(p_target);
     bool visible = obj->m_searchDock->isVisible();
     obj->m_searchDock->setVisible(!visible);
     if (!visible) {
@@ -2883,7 +2883,7 @@ bool VMainWindow::toggleSearchDockByCaptain(void *p_target, void *p_data)
 bool VMainWindow::closeFileByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VMainWindow *obj = static_cast<VMainWindow *>(p_target);
+    auto obj = static_cast<VMainWindow *>(p_target);
     obj->closeCurrentFile();
 
     QWidget *nextFocus = obj->m_editArea->getCurrentTab();
@@ -2899,7 +2899,7 @@ bool VMainWindow::closeFileByCaptain(void *p_target, void *p_data)
 bool VMainWindow::shortcutsHelpByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
-    VMainWindow *obj = static_cast<VMainWindow *>(p_target);
+    auto obj = static_cast<VMainWindow *>(p_target);
     obj->shortcutsHelp();
     return false;
 }
@@ -2921,7 +2921,7 @@ bool VMainWindow::exportByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
 
-    VMainWindow *obj = static_cast<VMainWindow *>(p_target);
+    auto obj = static_cast<VMainWindow *>(p_target);
     QTimer::singleShot(50, obj, SLOT(handleExportAct()));
 
     return true;
@@ -2931,7 +2931,7 @@ bool VMainWindow::focusEditAreaByCaptain(void *p_target, void *p_data)
 {
     Q_UNUSED(p_data);
 
-    VMainWindow *obj = static_cast<VMainWindow *>(p_target);
+    auto obj = static_cast<VMainWindow *>(p_target);
     obj->focusEditArea();
     return false;
 }
@@ -2991,10 +2991,10 @@ void VMainWindow::initHeadingButton(QToolBar *p_tb)
     m_headingBtn->setFocusPolicy(Qt::NoFocus);
     m_headingBtn->setEnabled(false);
 
-    QMenu *menu = new QMenu(this);
+    auto menu = new QMenu(this);
     QString text(tr("Heading %1"));
     QString tooltip(tr("Heading %1\t%2"));
-    QWidgetAction *wact = new QWidgetAction(menu);
+    auto wact = new QWidgetAction(menu);
     wact->setData(1);
     VButtonMenuItem *w = new VButtonMenuItem(wact, text.arg(1), this);
     w->setToolTip(tooltip.arg(1).arg(VUtils::getShortcutText("Ctrl+1")));
@@ -3086,7 +3086,7 @@ void VMainWindow::initThemeMenu(QMenu *p_menu)
 
     themeMenu->addAction(addAct);
 
-    QActionGroup *ag = new QActionGroup(this);
+    auto ag = new QActionGroup(this);
     connect(ag, &QActionGroup::triggered,
             this, [](QAction *p_action) {
                 QString data = p_action->data().toString();
@@ -3096,7 +3096,7 @@ void VMainWindow::initThemeMenu(QMenu *p_menu)
     QList<QString> themes = g_config->getThemes();
     QString theme = g_config->getTheme();
     for (auto const &item : themes) {
-        QAction *act = new QAction(item, ag);
+        auto act = new QAction(item, ag);
         act->setToolTip(tr("Set as the theme of VNote (restart VNote to make it work)"));
         act->setCheckable(true);
         act->setData(item);
@@ -3321,7 +3321,7 @@ void VMainWindow::initUniversalEntry()
             });
 
     // Register entries.
-    VSearchUE *searchUE = new VSearchUE(this);
+    auto searchUE = new VSearchUE(this);
     m_ue->registerEntry('q', searchUE, VSearchUE::Name_FolderNote_AllNotebook);
     m_ue->registerEntry('a', searchUE, VSearchUE::Content_Note_AllNotebook);
     m_ue->registerEntry('z', searchUE, VSearchUE::Tag_Note_AllNotebook);
@@ -3482,7 +3482,7 @@ void VMainWindow::updateFontOfAllTabs()
 {
     QVector<VEditTab *> tabs = m_editArea->getAllTabs();
     for (auto tab : tabs) {
-        const VMdTab *mdTab = dynamic_cast<const VMdTab *>(tab);
+        auto mdTab = dynamic_cast<const VMdTab *>(tab);
         if (mdTab && mdTab->getEditor()) {
             mdTab->getEditor()->updateFontAndPalette();
         }

--- a/src/vmathjaxinplacepreviewhelper.cpp
+++ b/src/vmathjaxinplacepreviewhelper.cpp
@@ -11,8 +11,7 @@
 extern VMainWindow *g_mainWin;
 
 MathjaxBlockPreviewInfo::MathjaxBlockPreviewInfo()
-{
-}
+= default;
 
 MathjaxBlockPreviewInfo::MathjaxBlockPreviewInfo(const VMathjaxBlock &p_mb)
     : m_mathjaxBlock(p_mb)
@@ -26,7 +25,7 @@ void MathjaxBlockPreviewInfo::updateInplacePreview(const VEditor *p_editor,
 {
     QTextBlock block = p_doc->findBlockByNumber(m_mathjaxBlock.m_blockNumber);
     if (block.isValid()) {
-        VImageToPreview *preview = new VImageToPreview();
+        auto *preview = new VImageToPreview();
 
         preview->m_startPos = block.position() + m_mathjaxBlock.m_index;
         preview->m_endPos = preview->m_startPos + m_mathjaxBlock.m_length;
@@ -99,8 +98,7 @@ void VMathJaxInplacePreviewHelper::updateMathjaxBlocks(const QVector<VMathjaxBlo
     m_mathjaxBlocks.clear();
     m_mathjaxBlocks.reserve(p_blocks.size());
     bool manualUpdate = true;
-    for (int i = 0; i < p_blocks.size(); ++i) {
-        const VMathjaxBlock &vmb = p_blocks[i];
+    for (const auto &vmb : p_blocks) {
         const QString &text = vmb.m_text;
         bool cached = false;
 
@@ -160,8 +158,7 @@ void VMathJaxInplacePreviewHelper::updateInplacePreview()
 {
     QSet<int> blocks;
     QVector<QSharedPointer<VImageToPreview> > images;
-    for (int i = 0; i < m_mathjaxBlocks.size(); ++i) {
-        MathjaxBlockPreviewInfo &mb = m_mathjaxBlocks[i];
+    for (auto &mb : m_mathjaxBlocks) {
         if (mb.inplacePreviewReady()) {
             if (!mb.inplacePreview()->m_image.isNull()) {
                 images.append(mb.inplacePreview());

--- a/src/vmdtab.cpp
+++ b/src/vmdtab.cpp
@@ -33,15 +33,15 @@ extern VConfigManager *g_config;
 VMdTab::VMdTab(VFile *p_file, VEditArea *p_editArea,
                OpenFileMode p_mode, QWidget *p_parent)
     : VEditTab(p_file, p_editArea, p_parent),
-      m_editor(NULL),
-      m_webViewer(NULL),
-      m_document(NULL),
+      m_editor(nullptr),
+      m_webViewer(nullptr),
+      m_document(nullptr),
       m_mdConType(g_config->getMdConverterType()),
       m_enableHeadingSequence(false),
       m_backupFileChecked(false),
       m_mode(Mode::InvalidMode),
-      m_livePreviewHelper(NULL),
-      m_mathjaxPreviewHelper(NULL)
+      m_livePreviewHelper(nullptr),
+      m_mathjaxPreviewHelper(nullptr)
 {
     V_ASSERT(m_file->getDocType() == DocType::Markdown);
 
@@ -49,7 +49,7 @@ VMdTab::VMdTab(VFile *p_file, VEditArea *p_editArea,
         VUtils::showMessage(QMessageBox::Warning,
                             tr("Warning"),
                             tr("Fail to open note <span style=\"%1\">%2</span>.")
-                              .arg(g_config->c_dataTextStyle).arg(m_file->getName()),
+                              .arg(VConfigManager::c_dataTextStyle).arg(m_file->getName()),
                             tr("Please check if file %1 exists.").arg(m_file->fetchPath()),
                             QMessageBox::Ok,
                             QMessageBox::Ok,
@@ -109,9 +109,9 @@ void VMdTab::setupUI()
     setupMarkdownViewer();
 
     // Setup editor when we really need it.
-    m_editor = NULL;
+    m_editor = nullptr;
 
-    QVBoxLayout *layout = new QVBoxLayout();
+    auto *layout = new QVBoxLayout();
     layout->addWidget(m_splitter);
     layout->setContentsMargins(0, 0, 0, 0);
     setLayout(layout);
@@ -441,7 +441,7 @@ void VMdTab::setupMarkdownViewer()
     connect(m_webViewer, &VWebView::requestExpandRestorePreviewArea,
             this, &VMdTab::expandRestorePreviewArea);
 
-    VPreviewPage *page = new VPreviewPage(m_webViewer);
+    auto *page = new VPreviewPage(m_webViewer);
     m_webViewer->setPage(page);
     m_webViewer->setZoomFactor(g_config->getWebZoomFactor());
     connect(page->profile(), &QWebEngineProfile::downloadRequested,
@@ -456,7 +456,7 @@ void VMdTab::setupMarkdownViewer()
     m_document = new VDocument(m_file, m_webViewer);
     m_documentID = m_document->registerIdentifier();
 
-    QWebChannel *channel = new QWebChannel(m_webViewer);
+    auto *channel = new QWebChannel(m_webViewer);
     channel->registerObject(QStringLiteral("content"), m_document);
     connect(m_document, &VDocument::tocChanged,
             this, &VMdTab::updateOutlineFromHtml);
@@ -949,7 +949,7 @@ void VMdTab::requestUpdateVimStatus()
     if (m_editor) {
         m_editor->requestUpdateVimStatus();
     } else {
-        emit vimStatusUpdated(NULL);
+        emit vimStatusUpdated(nullptr);
     }
 }
 
@@ -1106,11 +1106,7 @@ void VMdTab::applySnippet()
 
 static bool selectorItemCmp(const VInsertSelectorItem &p_a, const VInsertSelectorItem &p_b)
 {
-    if (p_a.m_shortcut < p_b.m_shortcut) {
-        return true;
-    }
-
-    return false;
+    return p_a.m_shortcut < p_b.m_shortcut;
 }
 
 VInsertSelector *VMdTab::prepareSnippetSelector(QWidget *p_parent)
@@ -1126,13 +1122,13 @@ VInsertSelector *VMdTab::prepareSnippetSelector(QWidget *p_parent)
     }
 
     if (items.isEmpty()) {
-        return NULL;
+        return nullptr;
     }
 
     // Sort items by shortcut.
     std::sort(items.begin(), items.end(), selectorItemCmp);
 
-    VInsertSelector *sel = new VInsertSelector(7, items, p_parent);
+    auto *sel = new VInsertSelector(7, items, p_parent);
     return sel;
 }
 
@@ -1470,7 +1466,7 @@ void VMdTab::handleDownloadRequested(QWebEngineDownloadItem *p_item)
 
 void VMdTab::handleSavePageRequested()
 {
-    static QString lastPath = g_config->getDocumentPathOrHomePath();
+    static QString lastPath = VConfigManager::getDocumentPathOrHomePath();
 
     QStringList filters;
     filters << tr("Single HTML (*.html)") << tr("Complete HTML (*.html)") << tr("MIME HTML (*.mht)");

--- a/src/vnavigationmode.cpp
+++ b/src/vnavigationmode.cpp
@@ -18,8 +18,7 @@ VNavigationMode::VNavigationMode()
 }
 
 VNavigationMode::~VNavigationMode()
-{
-}
+= default;
 
 void VNavigationMode::registerNavigation(QChar p_majorKey)
 {
@@ -76,7 +75,7 @@ QList<QListWidgetItem *> VNavigationMode::getVisibleItems(const QListWidget *p_w
         return items;
     }
 
-    QListWidgetItem *lastItem = NULL;
+    QListWidgetItem *lastItem = nullptr;
     lastItem = p_widget->itemAt(p_widget->viewport()->rect().bottomLeft());
 
     int first = p_widget->row(firstItem);
@@ -102,7 +101,7 @@ QList<QTreeWidgetItem *> VNavigationMode::getVisibleItems(const QTreeWidget *p_w
         return items;
     }
 
-    QTreeWidgetItem *lastItem = NULL;
+    QTreeWidgetItem *lastItem = nullptr;
     lastItem = p_widget->itemAt(p_widget->viewport()->rect().bottomLeft());
 
     QTreeWidgetItem *item = firstItem;

--- a/src/vnavigationmode.h
+++ b/src/vnavigationmode.h
@@ -5,6 +5,7 @@
 #include <QVector>
 #include <QMap>
 #include <QList>
+#include <QObject>
 
 class QLabel;
 class QListWidget;

--- a/src/vnotebookselector.cpp
+++ b/src/vnotebookselector.cpp
@@ -9,6 +9,7 @@
 #include <QLabel>
 #include <QDesktopServices>
 #include <QUrl>
+#include <QKeyEvent>
 
 #include "vnotebook.h"
 #include "vconfigmanager.h"
@@ -37,7 +38,7 @@ VNotebookSelector::VNotebookSelector(QWidget *p_parent)
       m_notebooks(g_vnote->getNotebooks()),
       m_lastValidIndex(-1),
       m_muted(false),
-      m_naviLabel(NULL)
+      m_naviLabel(nullptr)
 {
     m_listWidget = new QListWidget(this);
     m_listWidget->setItemDelegate(new VNoFocusItemDelegate(this));
@@ -65,8 +66,8 @@ void VNotebookSelector::updateComboBox()
 
     insertAddNotebookItem();
 
-    for (int i = 0; i < m_notebooks.size(); ++i) {
-        addNotebookItem(m_notebooks[i]);
+    for (auto &m_notebook : m_notebooks) {
+        addNotebookItem(m_notebook);
     }
 
     setCurrentIndex(-1);
@@ -86,7 +87,7 @@ void VNotebookSelector::restoreCurrentNotebook()
         index = 0;
     }
 
-    const VNotebook *nb = NULL;
+    const VNotebook *nb = nullptr;
     if (index < m_notebooks.size()) {
         nb = m_notebooks[index];
     }
@@ -107,7 +108,7 @@ int VNotebookSelector::itemIndexOfNotebook(const VNotebook *p_notebook) const
         return -1;
     }
 
-    qulonglong ptr = (qulonglong)p_notebook;
+    auto ptr = (qulonglong)p_notebook;
     int cnt = m_listWidget->count();
     for (int i = 0; i < cnt; ++i) {
         QListWidgetItem *item = m_listWidget->item(i);
@@ -121,7 +122,7 @@ int VNotebookSelector::itemIndexOfNotebook(const VNotebook *p_notebook) const
 
 void VNotebookSelector::insertAddNotebookItem()
 {
-    QListWidgetItem *item = new QListWidgetItem();
+    auto *item = new QListWidgetItem();
     item->setIcon(VIconUtils::comboBoxIcon(":/resources/icons/create_notebook.svg"));
     item->setText(tr("Add Notebook"));
     QFont font;
@@ -139,7 +140,7 @@ void VNotebookSelector::handleCurIndexChanged(int p_index)
     }
 
     QString tooltip = tr("View and edit notebooks");
-    VNotebook *nb = NULL;
+    VNotebook *nb = nullptr;
     if (p_index > -1) {
         nb = getNotebook(p_index);
         if (!nb) {
@@ -388,7 +389,7 @@ void VNotebookSelector::editNotebookInfo()
 
 void VNotebookSelector::addNotebookItem(const VNotebook *p_notebook)
 {
-    QListWidgetItem *item = new QListWidgetItem(m_listWidget);
+    auto *item = new QListWidgetItem(m_listWidget);
     fillItem(item, p_notebook);
 }
 
@@ -624,7 +625,7 @@ void VNotebookSelector::hideNavigation()
 {
     if (m_naviLabel) {
         delete m_naviLabel;
-        m_naviLabel = NULL;
+        m_naviLabel = nullptr;
     }
 }
 
@@ -658,7 +659,7 @@ bool VNotebookSelector::handlePopupKeyPress(QKeyEvent *p_event)
 
 VNotebook *VNotebookSelector::getNotebook(int p_itemIdx) const
 {
-    VNotebook *nb = NULL;
+    VNotebook *nb = nullptr;
     QListWidgetItem *item = m_listWidget->item(p_itemIdx);
     if (item) {
         nb = (VNotebook *)item->data(Qt::UserRole).toULongLong();
@@ -673,7 +674,7 @@ VNotebook *VNotebookSelector::getNotebook(const QListWidgetItem *p_item) const
         return (VNotebook *)p_item->data(Qt::UserRole).toULongLong();
     }
 
-    return NULL;
+    return nullptr;
 }
 
 VNotebook *VNotebookSelector::currentNotebook() const

--- a/src/voutline.cpp
+++ b/src/voutline.cpp
@@ -86,7 +86,7 @@ void VOutline::setupUI()
                 g_mainWin->showStatusMessage(tr("Set Outline Expanded Level to %1").arg(level));
             });
 
-    QHBoxLayout *btnLayout = new QHBoxLayout();
+    auto *btnLayout = new QHBoxLayout();
     btnLayout->addStretch();
     btnLayout->addWidget(m_deLevelBtn);
     btnLayout->addWidget(m_inLevelBtn);
@@ -109,7 +109,7 @@ void VOutline::setupUI()
                 activateItem(p_item, true);
             });
 
-    QVBoxLayout *layout = new QVBoxLayout();
+    auto *layout = new QVBoxLayout();
     layout->addLayout(btnLayout);
     layout->addWidget(m_tree);
     layout->setContentsMargins(3, 0, 3, 0);
@@ -147,7 +147,7 @@ void VOutline::updateTreeFromOutline(QTreeWidget *p_treeWidget,
 
     const QVector<VTableOfContentItem> &headers = p_outline.getTable();
     int idx = 0;
-    updateTreeByLevel(p_treeWidget, headers, idx, NULL, NULL, 1);
+    updateTreeByLevel(p_treeWidget, headers, idx, nullptr, nullptr, 1);
 }
 
 void VOutline::updateTreeByLevel(QTreeWidget *p_treeWidget,
@@ -174,7 +174,7 @@ void VOutline::updateTreeByLevel(QTreeWidget *p_treeWidget,
         } else if (header.m_level < p_level) {
             return;
         } else {
-            updateTreeByLevel(p_treeWidget, p_headers, p_index, p_last, NULL, p_level + 1);
+            updateTreeByLevel(p_treeWidget, p_headers, p_index, p_last, nullptr, p_level + 1);
         }
     }
 }
@@ -266,7 +266,7 @@ void VOutline::selectHeader(QTreeWidget *p_treeWidget,
                             const VTableOfContent &p_outline,
                             const VHeaderPointer &p_header)
 {
-    p_treeWidget->setCurrentItem(NULL);
+    p_treeWidget->setCurrentItem(nullptr);
 
     if (!p_outline.getItem(p_header)) {
         return;

--- a/src/voutlineue.cpp
+++ b/src/voutlineue.cpp
@@ -16,8 +16,8 @@ extern VMainWindow *g_mainWin;
 
 VOutlineUE::VOutlineUE(QObject *p_parent)
     : IUniversalEntry(p_parent),
-      m_listWidget(NULL),
-      m_treeWidget(NULL),
+      m_listWidget(nullptr),
+      m_treeWidget(nullptr),
       m_listOutline(true)
 {
 }
@@ -122,7 +122,7 @@ void VOutlineUE::processCommand(int p_id, const QString &p_cmd)
                 }
 
                 // Add item to list.
-                QListWidgetItem *item = new QListWidgetItem(it.m_name, m_listWidget);
+                auto *item = new QListWidgetItem(it.m_name, m_listWidget);
                 item->setData(Qt::UserRole, it.m_index);
                 item->setToolTip(it.m_name);
 

--- a/src/vsearch.cpp
+++ b/src/vsearch.cpp
@@ -14,7 +14,7 @@ extern VMainWindow *g_mainWin;
 VSearch::VSearch(QObject *p_parent)
     : QObject(p_parent),
       m_askedToStop(false),
-      m_engine(NULL)
+      m_engine(nullptr)
 {
     m_slashReg = QRegExp("[\\/]");
 }
@@ -468,12 +468,12 @@ VSearchResultItem *VSearch::searchForOutline(const VFile *p_file) const
 {
     VEditTab *tab = g_mainWin->getEditArea()->getTab(p_file);
     if (!tab) {
-        return NULL;
+        return nullptr;
     }
 
     const VTableOfContent &toc = tab->getOutline();
     const QVector<VTableOfContentItem> &table = toc.getTable();
-    VSearchResultItem *item = NULL;
+    VSearchResultItem *item = nullptr;
     for (auto const & it: table) {
         if (it.isEmpty()) {
             continue;
@@ -501,10 +501,10 @@ VSearchResultItem *VSearch::searchForOutline(const VFile *p_file) const
 VSearchResultItem *VSearch::searchForTag(const VFile *p_file) const
 {
     if (p_file->getType() != FileType::Note) {
-        return NULL;
+        return nullptr;
     }
 
-    const VNoteFile *file = static_cast<const VNoteFile *>(p_file);
+    const auto *file = static_cast<const VNoteFile *>(p_file);
     const QStringList &tags = file->getTags();
 
     VSearchToken &contentToken = m_config->m_contentToken;
@@ -513,7 +513,7 @@ VSearchResultItem *VSearch::searchForTag(const VFile *p_file) const
         contentToken.startBatchMode();
     }
 
-    VSearchResultItem *item = NULL;
+    VSearchResultItem *item = nullptr;
     bool allMatched = false;
 
     for (int i = 0; i < tags.size(); ++i) {
@@ -522,7 +522,7 @@ VSearchResultItem *VSearch::searchForTag(const VFile *p_file) const
             continue;
         }
 
-        bool matched = false;
+        bool matched;
         if (singleToken) {
             matched = contentToken.matched(tag);
         } else {
@@ -553,7 +553,7 @@ VSearchResultItem *VSearch::searchForTag(const VFile *p_file) const
         if (!allMatched && item) {
             // This file does not meet all the tokens.
             delete item;
-            item = NULL;
+            item = nullptr;
         }
     }
 
@@ -565,10 +565,10 @@ VSearchResultItem *VSearch::searchForContent(const VFile *p_file) const
     Q_ASSERT(p_file->isOpened());
     const QString &content = p_file->getContent();
     if (content.isEmpty()) {
-        return NULL;
+        return nullptr;
     }
 
-    VSearchResultItem *item = NULL;
+    VSearchResultItem *item = nullptr;
     int lineNum = 1;
     int pos = 0;
     int size = content.size();
@@ -629,7 +629,7 @@ VSearchResultItem *VSearch::searchForContent(const VFile *p_file) const
         if (!allMatched && item) {
             // This file does not meet all the tokens.
             delete item;
-            item = NULL;
+            item = nullptr;
         }
     }
 
@@ -639,7 +639,7 @@ VSearchResultItem *VSearch::searchForContent(const VFile *p_file) const
 void VSearch::searchSecondPhase(const QSharedPointer<VSearchResult> &p_result)
 {
     delete m_engine;
-    m_engine = NULL;
+    m_engine = nullptr;
 
     switch (m_config->m_engine) {
     case VSearchConfig::Internal:
@@ -670,7 +670,7 @@ void VSearch::clear()
         m_engine->clear();
 
         delete m_engine;
-        m_engine = NULL;
+        m_engine = nullptr;
     }
 
     m_askedToStop = false;

--- a/src/vsearchengine.cpp
+++ b/src/vsearchengine.cpp
@@ -71,11 +71,11 @@ VSearchResultItem *VSearchEngineWorker::searchFile(const QString &p_fileName)
 {
     QFile file(p_fileName);
     if (!file.open(QIODevice::ReadOnly)) {
-        return NULL;
+        return nullptr;
     }
 
     int lineNum = 1;
-    VSearchResultItem *item = NULL;
+    VSearchResultItem *item = nullptr;
     QString line;
     QTextStream in(&file);
 
@@ -94,7 +94,7 @@ VSearchResultItem *VSearchEngineWorker::searchFile(const QString &p_fileName)
         }
 
         line = in.readLine();
-        bool matched = false;
+        bool matched;
         if (singleToken) {
             matched = m_token.matched(line);
         } else {
@@ -127,7 +127,7 @@ VSearchResultItem *VSearchEngineWorker::searchFile(const QString &p_fileName)
 
         if (!allMatched && item) {
             delete item;
-            item = NULL;
+            item = nullptr;
         }
     }
 
@@ -198,7 +198,7 @@ void VSearchEngine::search(const QSharedPointer<VSearchConfig> &p_config,
             len = totalSize - start;
         }
 
-        VSearchEngineWorker *th = new VSearchEngineWorker(this);
+        auto *th = new VSearchEngineWorker(this);
         th->setData(m_result->m_secondPhaseItems.mid(start, len),
                     p_config->m_contentToken,
                     p_config);

--- a/src/vsearcher.cpp
+++ b/src/vsearcher.cpp
@@ -86,7 +86,7 @@ void VSearcher::setupUI()
 
     m_numLabel = new QLabel(this);
 
-    QHBoxLayout *btnLayout = new QHBoxLayout();
+    auto *btnLayout = new QHBoxLayout();
     btnLayout->addWidget(m_searchBtn);
     btnLayout->addWidget(m_clearBtn);
     btnLayout->addWidget(m_advBtn);
@@ -194,7 +194,7 @@ void VSearcher::setupUI()
                 }
             });
 
-    QHBoxLayout *proLayout = new QHBoxLayout();
+    auto *proLayout = new QHBoxLayout();
     proLayout->addWidget(m_proBar);
     proLayout->addWidget(m_cancelBtn);
     proLayout->setContentsMargins(0, 0, 0, 0);
@@ -229,7 +229,7 @@ void VSearcher::setupUI()
     formLayout->addRow(tr("Target:"), m_searchTargetCB);
     formLayout->setContentsMargins(0, 0, 0, 0);
 
-    QVBoxLayout *mainLayout = new QVBoxLayout();
+    auto *mainLayout = new QVBoxLayout();
     mainLayout->addLayout(btnLayout);
     mainLayout->addLayout(formLayout);
     mainLayout->addWidget(m_advWidget);
@@ -606,13 +606,13 @@ void VSearcher::init()
     connect(&m_search, &VSearch::resultItemAdded,
             this, [this](const QSharedPointer<VSearchResultItem> &p_item) {
                 // Not sure if it works.
-                QCoreApplication::sendPostedEvents(NULL, QEvent::MouseButtonRelease);
+                QCoreApplication::sendPostedEvents(nullptr, QEvent::MouseButtonRelease);
                 m_results->addResultItem(p_item);
             });
     connect(&m_search, &VSearch::resultItemsAdded,
             this, [this](const QList<QSharedPointer<VSearchResultItem> > &p_items) {
                 // Not sure if it works.
-                QCoreApplication::sendPostedEvents(NULL, QEvent::MouseButtonRelease);
+                QCoreApplication::sendPostedEvents(nullptr, QEvent::MouseButtonRelease);
                 m_results->addResultItems(p_items);
             });
     connect(&m_search, &VSearch::finished,

--- a/src/vsearchresulttree.cpp
+++ b/src/vsearchresulttree.cpp
@@ -80,8 +80,7 @@ void VSearchResultTree::appendItem(const QSharedPointer<VSearchResultItem> &p_it
 {
     m_data.append(p_item);
 
-    QTreeWidgetItem *item = new QTreeWidgetItem(this);
-    item->setData(0, Qt::UserRole, m_data.size() - 1);
+    auto *item = new QTreeWidgetItem(this); item->setData(0, Qt::UserRole, m_data.size() - 1);
     QString text;
     if (p_item->m_text.isEmpty()) {
         text = p_item->m_path;
@@ -111,7 +110,7 @@ void VSearchResultTree::appendItem(const QSharedPointer<VSearchResultItem> &p_it
     }
 
     for (auto const & it: p_item->m_matches) {
-        QTreeWidgetItem *subItem = new QTreeWidgetItem(item);
+        auto *subItem = new QTreeWidgetItem(item);
         QString text;
         if (it.m_lineNumber > -1) {
             text = QString("[%1] %2").arg(it.m_lineNumber).arg(it.m_text);
@@ -223,8 +222,8 @@ void VSearchResultTree::addSelectedItemsToCart()
     VCart *cart = g_mainWin->getCart();
 
     int nrAdded = 0;
-    for (int i = 0; i < items.size(); ++i) {
-        const QSharedPointer<VSearchResultItem> &resItem = itemResultData(items[i]);
+    for (auto &item : items) {
+        const QSharedPointer<VSearchResultItem> &resItem = itemResultData(item);
         if (resItem->m_type == VSearchResultItem::Note) {
             cart->addFile(resItem->m_path);
             ++nrAdded;
@@ -242,8 +241,8 @@ void VSearchResultTree::pinSelectedItemsToHistory()
 {
     QList<QTreeWidgetItem *> items = selectedItems();
     QStringList files;
-    for (int i = 0; i < items.size(); ++i) {
-        const QSharedPointer<VSearchResultItem> &resItem = itemResultData(items[i]);
+    for (auto &item : items) {
+        const QSharedPointer<VSearchResultItem> &resItem = itemResultData(item);
         if (resItem->m_type == VSearchResultItem::Note) {
             files << resItem->m_path;
         }

--- a/src/vsearchue.cpp
+++ b/src/vsearchue.cpp
@@ -30,11 +30,11 @@ extern VConfigManager *g_config;
 
 VSearchUE::VSearchUE(QObject *p_parent)
     : IUniversalEntry(p_parent),
-      m_search(NULL),
+      m_search(nullptr),
       m_inSearch(false),
       m_id(ID::Name_Notebook_AllNotebook),
-      m_listWidget(NULL),
-      m_treeWidget(NULL)
+      m_listWidget(nullptr),
+      m_treeWidget(nullptr)
 {
 }
 
@@ -162,7 +162,7 @@ QWidget *VSearchUE::widget(int p_id)
 
     default:
         Q_ASSERT(false);
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -648,7 +648,7 @@ void VSearchUE::handleSearchItemAdded(const QSharedPointer<VSearchResultItem> &p
     static int itemAdded = 0;
     ++itemAdded;
 
-    QCoreApplication::sendPostedEvents(NULL, QEvent::KeyPress);
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::KeyPress);
 
     switch (m_id) {
     case ID::Name_Notebook_AllNotebook:
@@ -693,7 +693,7 @@ void VSearchUE::handleSearchItemAdded(const QSharedPointer<VSearchResultItem> &p
 
 void VSearchUE::handleSearchItemsAdded(const QList<QSharedPointer<VSearchResultItem> > &p_items)
 {
-    QCoreApplication::sendPostedEvents(NULL, QEvent::KeyPress);
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::KeyPress);
 
     switch (m_id) {
     case ID::Name_Notebook_AllNotebook:
@@ -754,7 +754,7 @@ void VSearchUE::appendItemToList(const QSharedPointer<VSearchResultItem> &p_item
         second = p_item->m_path;
     }
 
-    QIcon *icon = NULL;
+    QIcon *icon = nullptr;
     // We put notebook and folder before note.
     int row = 0;
     switch (p_item->m_type) {
@@ -788,7 +788,7 @@ void VSearchUE::appendItemToTree(const QSharedPointer<VSearchResultItem> &p_item
 {
     m_data.append(p_item);
 
-    QTreeWidgetItem *item = new QTreeWidgetItem(m_treeWidget);
+    auto *item = new QTreeWidgetItem(m_treeWidget);
     item->setData(0, Qt::UserRole, m_data.size() - 1);
     QString text;
     if (p_item->m_text.isEmpty()) {
@@ -819,7 +819,7 @@ void VSearchUE::appendItemToTree(const QSharedPointer<VSearchResultItem> &p_item
     }
 
     for (auto const & it: p_item->m_matches) {
-        QTreeWidgetItem *subItem = new QTreeWidgetItem(item);
+        auto *subItem = new QTreeWidgetItem(item);
         QString text;
         if (it.m_lineNumber > -1) {
             text = QString("[%1] %2").arg(it.m_lineNumber).arg(it.m_text);

--- a/src/vsnippetlist.cpp
+++ b/src/vsnippetlist.cpp
@@ -52,7 +52,7 @@ void VSnippetList::setupUI()
 
     m_numLabel = new QLabel();
 
-    QHBoxLayout *btnLayout = new QHBoxLayout;
+    auto btnLayout = new QHBoxLayout;
     btnLayout->addWidget(m_addBtn);
     btnLayout->addWidget(m_locateBtn);
     btnLayout->addStretch();
@@ -68,7 +68,7 @@ void VSnippetList::setupUI()
     connect(m_snippetList, &QListWidget::itemActivated,
             this, &VSnippetList::handleItemActivated);
 
-    QVBoxLayout *mainLayout = new QVBoxLayout();
+    auto *mainLayout = new QVBoxLayout();
     mainLayout->addLayout(btnLayout);
     mainLayout->addWidget(m_snippetList);
     mainLayout->setContentsMargins(3, 0, 3, 0);
@@ -207,7 +207,7 @@ void VSnippetList::deleteSelectedItems()
         items.push_back(ConfirmItemInfo(name,
                                         name,
                                         "",
-                                        NULL));
+                                        nullptr));
     }
 
     QString text = tr("Are you sure to delete these snippets?");
@@ -365,12 +365,11 @@ void VSnippetList::updateContent()
 {
     m_snippetList->clearAll();
 
-    for (int i = 0; i < m_snippets.size(); ++i) {
-        const VSnippet &snip = m_snippets[i];
+    for (const auto &snip : m_snippets) {
         QString text = QString("%1%2").arg(snip.getName())
                                       .arg(snip.getShortcut().isNull()
                                            ? "" : QString(" [%1]").arg(snip.getShortcut()));
-        QListWidgetItem *item = new QListWidgetItem(text);
+        auto *item = new QListWidgetItem(text);
         item->setToolTip(snip.getName());
         item->setData(Qt::UserRole, snip.getName());
 
@@ -416,8 +415,8 @@ bool VSnippetList::writeSnippetsToConfig() const
     snippetJson[SnippetConfig::c_version] = "1";
 
     QJsonArray snippetArray;
-    for (int i = 0; i < m_snippets.size(); ++i) {
-        snippetArray.append(m_snippets[i].toJson());
+    for (const auto &m_snippet : m_snippets) {
+        snippetArray.append(m_snippet.toJson());
     }
 
     snippetJson[SnippetConfig::c_snippets] = snippetArray;
@@ -443,8 +442,8 @@ bool VSnippetList::readSnippetsFromConfig()
     // [snippets] section.
     bool ret = true;
     QJsonArray snippetArray = snippets[SnippetConfig::c_snippets].toArray();
-    for (int i = 0; i < snippetArray.size(); ++i) {
-        VSnippet snip = VSnippet::fromJson(snippetArray[i].toObject());
+    for (auto &&i : snippetArray) {
+        VSnippet snip = VSnippet::fromJson(i.toObject());
 
         // Read the content.
         QString filePath(QDir(g_config->getSnippetConfigFolder()).filePath(snip.getName()));
@@ -509,7 +508,7 @@ VSnippet *VSnippetList::getSnippet(QListWidgetItem *p_item)
 {
     int idx = getSnippetIndex(p_item);
     if (idx == -1) {
-        return NULL;
+        return nullptr;
     } else {
         return &m_snippets[idx];
     }

--- a/src/vtabindicator.cpp
+++ b/src/vtabindicator.cpp
@@ -24,7 +24,7 @@ VWordCountPanel::VWordCountPanel(QWidget *p_parent)
     m_charWithSpacesLabel = new QLabel();
     m_charWithSpacesLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 
-    QFormLayout *readLayout = new QFormLayout();
+    auto *readLayout = new QFormLayout();
     readLayout->addRow(tr("Words"), m_wordLabel);
     readLayout->addRow(tr("Characters (no spaces)"), m_charWithoutSpacesLabel);
     readLayout->addRow(tr("Characters (with spaces)"), m_charWithSpacesLabel);
@@ -38,19 +38,19 @@ VWordCountPanel::VWordCountPanel(QWidget *p_parent)
     m_charWithSpacesEditLabel = new QLabel();
     m_charWithSpacesEditLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 
-    QLabel *cwsLabel = new QLabel(tr("Characters (with spaces)"));
+    auto cwsLabel = new QLabel(tr("Characters (with spaces)"));
     cwsLabel->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred);
 
-    QFormLayout *editLayout = new QFormLayout();
+    auto *editLayout = new QFormLayout();
     editLayout->addRow(tr("Words"), m_wordEditLabel);
     editLayout->addRow(tr("Characters (no spaces)"), m_charWithoutSpacesEditLabel);
     editLayout->addRow(cwsLabel, m_charWithSpacesEditLabel);
     m_editBox = new QGroupBox(tr("Edit"));
     m_editBox->setLayout(editLayout);
 
-    QLabel *titleLabel = new QLabel(tr("Word Count"));
+    auto titleLabel = new QLabel(tr("Word Count"));
     titleLabel->setProperty("TitleLabel", true);
-    QVBoxLayout *mainLayout = new QVBoxLayout();
+    auto *mainLayout = new QVBoxLayout();
     mainLayout->addWidget(titleLabel);
     mainLayout->addWidget(m_readBox);
     mainLayout->addWidget(m_editBox);
@@ -98,7 +98,7 @@ void VWordCountPanel::clear()
 
 VTabIndicator::VTabIndicator(QWidget *p_parent)
     : QWidget(p_parent),
-      m_editTab(NULL)
+      m_editTab(nullptr)
 {
     setupUI();
 }
@@ -141,7 +141,7 @@ void VTabIndicator::setupUI()
     connect(m_wordCountBtn, &VButtonWithWidget::popupWidgetAboutToShow,
             this, &VTabIndicator::updateWordCountInfo);
 
-    QHBoxLayout *mainLayout = new QHBoxLayout(this);
+    auto *mainLayout = new QHBoxLayout(this);
     mainLayout->addWidget(m_tagPanel);
     mainLayout->addWidget(m_cursorLabel);
     mainLayout->addWidget(m_wordCountBtn);
@@ -185,7 +185,7 @@ static QString docTypeToString(DocType p_type)
 
 void VTabIndicator::update(const VEditTabInfo &p_info)
 {
-    VFile *file = NULL;
+    VFile *file = nullptr;
     DocType docType = DocType::Html;
     bool readonly = false;
     bool external = false;
@@ -225,7 +225,7 @@ void VTabIndicator::update(const VEditTabInfo &p_info)
 
     m_tagPanel->setVisible(!external);
     if (external) {
-        m_tagPanel->updateTags(NULL);
+        m_tagPanel->updateTags(nullptr);
     } else {
         m_tagPanel->updateTags(dynamic_cast<VNoteFile *>(file));
     }
@@ -244,7 +244,7 @@ void VTabIndicator::update(const VEditTabInfo &p_info)
 
 void VTabIndicator::updateWordCountInfo(QWidget *p_widget)
 {
-    VWordCountPanel *wcp = dynamic_cast<VWordCountPanel *>(p_widget);
+    auto *wcp = dynamic_cast<VWordCountPanel *>(p_widget);
 
     if (!m_editTab) {
         wcp->clear();

--- a/src/vtagexplorer.cpp
+++ b/src/vtagexplorer.cpp
@@ -27,9 +27,9 @@ extern VNote *g_vnote;
 VTagExplorer::VTagExplorer(QWidget *p_parent)
     : QWidget(p_parent),
       m_uiInitialized(false),
-      m_notebook(NULL),
+      m_notebook(nullptr),
       m_notebookChanged(true),
-      m_search(NULL)
+      m_search(nullptr)
 {
 }
 
@@ -59,7 +59,7 @@ void VTagExplorer::setupUI()
                 }
             });
 
-    QVBoxLayout *tagLayout = new QVBoxLayout();
+    auto *tagLayout = new QVBoxLayout();
     tagLayout->addWidget(m_notebookLabel);
     tagLayout->addWidget(m_tagList);
     tagLayout->setContentsMargins(0, 0, 0, 0);
@@ -84,7 +84,7 @@ void VTagExplorer::setupUI()
                 saveStateAndGeometry();
             });
 
-    QHBoxLayout *titleLayout = new QHBoxLayout();
+    auto *titleLayout = new QHBoxLayout();
     titleLayout->addWidget(m_tagLabel);
     titleLayout->addWidget(m_splitBtn);
     titleLayout->addStretch();
@@ -99,7 +99,7 @@ void VTagExplorer::setupUI()
     connect(m_fileList, &QListWidget::customContextMenuRequested,
             this, &VTagExplorer::handleFileListContextMenuRequested);
 
-    QVBoxLayout *fileLayout = new QVBoxLayout();
+    auto *fileLayout = new QVBoxLayout();
     fileLayout->addLayout(titleLayout);
     fileLayout->addWidget(m_fileList);
     fileLayout->setContentsMargins(0, 0, 0, 0);
@@ -114,7 +114,7 @@ void VTagExplorer::setupUI()
 
     setupFileListSplitOut(g_config->getEnableSplitTagFileList());
 
-    QVBoxLayout *mainLayout = new QVBoxLayout();
+    auto *mainLayout = new QVBoxLayout();
     mainLayout->addWidget(m_splitter);
     mainLayout->setContentsMargins(0, 0, 0, 0);
 
@@ -333,7 +333,7 @@ void VTagExplorer::appendItemToFileList(const QSharedPointer<VSearchResultItem> 
 {
     Q_ASSERT(p_item->m_type == VSearchResultItem::Note);
 
-    QListWidgetItem *item = new QListWidgetItem(m_noteIcon,
+    auto *item = new QListWidgetItem(m_noteIcon,
                                                 p_item->m_text.isEmpty() ? p_item->m_path : p_item->m_text);
     item->setData(Qt::UserRole, p_item->m_path);
     item->setToolTip(p_item->m_path);
@@ -479,8 +479,8 @@ void VTagExplorer::addFileToCart() const
     QList<QListWidgetItem *> items = m_fileList->selectedItems();
     VCart *cart = g_mainWin->getCart();
 
-    for (int i = 0; i < items.size(); ++i) {
-        cart->addFile(getFilePath(items[i]));
+    for (auto &item : items) {
+        cart->addFile(getFilePath(item));
     }
 
     g_mainWin->showStatusMessage(tr("%1 %2 added to Cart")
@@ -493,8 +493,8 @@ void VTagExplorer::pinFileToHistory() const
     QList<QListWidgetItem *> items = m_fileList->selectedItems();
 
     QStringList files;
-    for (int i = 0; i < items.size(); ++i) {
-        files << getFilePath(items[i]);
+    for (auto &item : items) {
+        files << getFilePath(item);
     }
 
     g_mainWin->getHistoryList()->pinFiles(files);
@@ -513,7 +513,7 @@ void VTagExplorer::promptToRemoveEmptyTag(const QString &p_tag)
                                   tr("Empty tag detected! Do you want to remove it?"),
                                   tr("The tag <span style=\"%1\">%2</span> seems not to "
                                      "be assigned to any note currently.")
-                                    .arg(g_config->c_dataTextStyle)
+                                    .arg(VConfigManager::c_dataTextStyle)
                                     .arg(p_tag),
                                   QMessageBox::Ok | QMessageBox::Cancel,
                                   QMessageBox::Cancel,
@@ -533,10 +533,10 @@ void VTagExplorer::registerNavigationTarget()
 {
     setupUI();
 
-    VNavigationModeListWidgetWrapper *tagWrapper = new VNavigationModeListWidgetWrapper(m_tagList, this);
+    auto *tagWrapper = new VNavigationModeListWidgetWrapper(m_tagList, this);
     g_mainWin->getCaptain()->registerNavigationTarget(tagWrapper);
 
-    VNavigationModeListWidgetWrapper *fileWrapper = new VNavigationModeListWidgetWrapper(m_fileList, this);
+    auto *fileWrapper = new VNavigationModeListWidgetWrapper(m_fileList, this);
     g_mainWin->getCaptain()->registerNavigationTarget(fileWrapper);
 }
 

--- a/src/vtagpanel.cpp
+++ b/src/vtagpanel.cpp
@@ -22,8 +22,8 @@ extern VConfigManager *g_config;
 
 VTagPanel::VTagPanel(QWidget *parent)
     : QWidget(parent),
-      m_file(NULL),
-      m_notebookOfCompleter(NULL)
+      m_file(nullptr),
+      m_notebookOfCompleter(nullptr)
 {
     setupUI();
 }
@@ -32,7 +32,7 @@ void VTagPanel::setupUI()
 {
     const int maxNum = g_config->getMaxNumOfTagLabels();
     for (int i = 0; i < maxNum; ++i) {
-        VTagLabel *label = new VTagLabel(this);
+        auto *label = new VTagLabel(this);
         connect(label, &VTagLabel::removalRequested,
                 this, [this](const QString &p_text) {
                     removeTag(p_text);
@@ -94,13 +94,13 @@ void VTagPanel::setupUI()
 
     // Completer.
     m_tagsModel = new QStringListModel(this);
-    QCompleter *completer = new QCompleter(m_tagsModel, this);
+    auto *completer = new QCompleter(m_tagsModel, this);
     completer->setCaseSensitivity(Qt::CaseSensitive);
     completer->popup()->setItemDelegate(new QStyledItemDelegate(this));
     m_tagEdit->setCompleter(completer);
     m_tagEdit->installEventFilter(this);
 
-    QHBoxLayout *mainLayout = new QHBoxLayout();
+    auto *mainLayout = new QHBoxLayout();
     for (auto label : m_labels) {
         mainLayout->addWidget(label);
         label->hide();
@@ -190,7 +190,7 @@ bool VTagPanel::eventFilter(QObject *p_obj, QEvent *p_event)
     Q_ASSERT(p_obj == m_tagEdit);
 
     if (p_event->type() == QEvent::FocusIn) {
-        QFocusEvent *eve = static_cast<QFocusEvent *>(p_event);
+        auto *eve = static_cast<QFocusEvent *>(p_event);
         if (eve->gotFocus()) {
             // Just check completer.
             updateCompleter(m_file);
@@ -202,7 +202,7 @@ bool VTagPanel::eventFilter(QObject *p_obj, QEvent *p_event)
 
 void VTagPanel::updateCompleter(const VNoteFile *p_file)
 {
-    const VNotebook *nb = p_file ? p_file->getNotebook() : NULL;
+    const VNotebook *nb = p_file ? p_file->getNotebook() : nullptr;
     if (nb == m_notebookOfCompleter) {
         // No need to update.
         return;

--- a/src/vtextdocumentlayout.cpp
+++ b/src/vtextdocumentlayout.cpp
@@ -327,8 +327,7 @@ QVector<QTextLayout::FormatRange> VTextDocumentLayout::formatRangeFromSelection(
 
     int blpos = p_block.position();
     int bllen = p_block.length();
-    for (int i = 0; i < p_selections.size(); ++i) {
-        const QAbstractTextDocumentLayout::Selection &range = p_selections.at(i);
+    for (const auto &range : p_selections) {
         const int selStart = range.cursor.selectionStart() - blpos;
         const int selEnd = range.cursor.selectionEnd() - blpos;
         if (selStart < bllen
@@ -625,7 +624,7 @@ qreal VTextDocumentLayout::layoutLines(const QTextBlock &p_block,
 
     // Handle block inline image.
     bool hasInlineImages = false;
-    const QVector<VPreviewInfo *> *info = NULL;
+    const QVector<VPreviewInfo *> *info = nullptr;
     if (m_blockImageEnabled) {
         VTextBlockData *blockData = VTextBlockData::blockData(p_block);
         info = &(blockData->getPreviews());

--- a/src/vtexteditcompleter.cpp
+++ b/src/vtexteditcompleter.cpp
@@ -153,7 +153,7 @@ bool VTextEditCompleter::eventFilter(QObject *p_obj, QEvent *p_eve)
 
         bool exited = false;
 
-        QKeyEvent *ke = static_cast<QKeyEvent *>(p_eve);
+        auto *ke = dynamic_cast<QKeyEvent *>(p_eve);
         const int key = ke->key();
         const int modifiers = ke->modifiers();
         switch (key) {
@@ -300,7 +300,7 @@ void VTextEditCompleter::cleanUp()
 {
     // Do not clean up m_editor and m_insertedCompletion, since activated()
     // signal is after the HideEvent.
-    setWidget(NULL);
+    setWidget(nullptr);
     g_mainWin->setCaptainModeEnabled(true);
 }
 

--- a/src/vtoolbox.cpp
+++ b/src/vtoolbox.cpp
@@ -32,7 +32,7 @@ void VToolBox::setupUI()
 
     m_widgetLayout = new QStackedLayout();
 
-    QVBoxLayout *mainLayout = new QVBoxLayout();
+    auto *mainLayout = new QVBoxLayout();
     mainLayout->addWidget(wid);
     mainLayout->addLayout(m_widgetLayout);
     mainLayout->setContentsMargins(3, 0, 3, 0);
@@ -125,10 +125,10 @@ void VToolBox::setCurrentWidget(QWidget *p_widget, bool p_focus)
 void VToolBox::setCurrentButtonIndex(int p_idx)
 {
     // Remove the text of all button.
-    for (int i = 0; i < m_items.size(); ++i) {
-        QPushButton *btn = m_items[i].m_btn;
+    for (auto &m_item : m_items) {
+        QPushButton *btn = m_item.m_btn;
         btn->setText("");
-        btn->setIcon(m_items[i].m_icon);
+        btn->setIcon(m_item.m_icon);
         btn->clearFocus();
         VUtils::setDynamicProperty(btn, "ToolBoxActiveBtn", false);
     }
@@ -179,7 +179,7 @@ bool VToolBox::handleKeyNavigation(int p_key, bool &p_succeed)
         auto it = m_keyMap.find(keyChar);
         if (it != m_keyMap.end()) {
             ret = true;
-            QWidget *widget = static_cast<QWidget *>(it.value());
+            auto *widget = static_cast<QWidget *>(it.value());
             setCurrentWidget(widget);
         }
     } else if (keyChar == m_majorKey) {

--- a/src/vvimindicator.cpp
+++ b/src/vvimindicator.cpp
@@ -17,7 +17,7 @@
 extern VConfigManager *g_config;
 
 VVimIndicator::VVimIndicator(QWidget *p_parent)
-    : QWidget(p_parent), m_vim(NULL)
+    : QWidget(p_parent), m_vim(nullptr)
 {
     setupUI();
 }
@@ -27,7 +27,7 @@ void VVimIndicator::setupUI()
     m_modeLabel = new QLabel(this);
     m_modeLabel->setProperty("VimIndicatorModeLabel", true);
 
-    QTreeWidget *regTree = new QTreeWidget(this);
+    auto *regTree = new QTreeWidget(this);
     regTree->setProperty("ItemBorder", true);
     regTree->setRootIsDecorated(false);
     regTree->setColumnCount(2);
@@ -45,7 +45,7 @@ void VVimIndicator::setupUI()
     connect(m_regBtn, &VButtonWithWidget::popupWidgetAboutToShow,
             this, &VVimIndicator::updateRegistersTree);
 
-    QTreeWidget *markTree = new QTreeWidget(this);
+    auto *markTree = new QTreeWidget(this);
     markTree->setProperty("ItemBorder", true);
     markTree->setRootIsDecorated(false);
     markTree->setColumnCount(4);
@@ -68,7 +68,7 @@ void VVimIndicator::setupUI()
     QFontMetrics metric(font());
     m_keyLabel->setMinimumWidth(metric.width('A') * 5);
 
-    QHBoxLayout *mainLayout = new QHBoxLayout(this);
+    auto *mainLayout = new QHBoxLayout(this);
     mainLayout->addWidget(m_modeLabel);
     mainLayout->addWidget(m_regBtn);
     mainLayout->addWidget(m_markBtn);
@@ -155,7 +155,7 @@ static void fillTreeItemsWithRegisters(QTreeWidget *p_tree,
 
         QStringList itemStr;
         itemStr << reg.m_name << reg.m_value;
-        QTreeWidgetItem *item = new QTreeWidgetItem(p_tree, itemStr);
+        auto *item = new QTreeWidgetItem(p_tree, itemStr);
         item->setFlags(item->flags() | Qt::ItemIsSelectable | Qt::ItemIsEditable);
     }
 
@@ -195,7 +195,7 @@ void VVimIndicator::update(const VVim *p_vim)
 
 void VVimIndicator::updateRegistersTree(QWidget *p_widget)
 {
-    QTreeWidget *regTree = dynamic_cast<QTreeWidget *>(p_widget);
+    auto *regTree = dynamic_cast<QTreeWidget *>(p_widget);
     if (!m_vim) {
         regTree->clear();
         return;
@@ -217,7 +217,7 @@ static void fillTreeItemsWithMarks(QTreeWidget *p_tree,
         QStringList itemStr;
         itemStr << mark.m_name << QString::number(mark.m_location.m_blockNumber + 1)
                 << QString::number(mark.m_location.m_positionInBlock) << mark.m_text;
-        QTreeWidgetItem *item = new QTreeWidgetItem(p_tree, itemStr);
+        auto *item = new QTreeWidgetItem(p_tree, itemStr);
         item->setFlags(item->flags() | Qt::ItemIsSelectable | Qt::ItemIsEditable);
     }
 
@@ -229,7 +229,7 @@ static void fillTreeItemsWithMarks(QTreeWidget *p_tree,
 
 void VVimIndicator::updateMarksTree(QWidget *p_widget)
 {
-    QTreeWidget *markTree = dynamic_cast<QTreeWidget *>(p_widget);
+    auto *markTree = dynamic_cast<QTreeWidget *>(p_widget);
     if (!m_vim) {
         markTree->clear();
         return;

--- a/src/vwaitingwidget.cpp
+++ b/src/vwaitingwidget.cpp
@@ -17,12 +17,12 @@ void VWaitingWidget::setupUI()
     QLabel *logoLabel = new QLabel();
     logoLabel->setPixmap(QPixmap(":/resources/icons/vnote.svg").scaled(imgSize, Qt::KeepAspectRatio));
 
-    QHBoxLayout *layout = new QHBoxLayout();
+    auto *layout = new QHBoxLayout();
     layout->addStretch();
     layout->addWidget(logoLabel);
     layout->addStretch();
 
-    QVBoxLayout *mainLayout = new QVBoxLayout();
+    auto *mainLayout = new QVBoxLayout();
     mainLayout->addStretch();
     mainLayout->addLayout(layout);
     mainLayout->addStretch();


### PR DESCRIPTION
- Fix following clang-tidy warnings
  * warning: use range-based for loop instead [modernize-loop-convert]
  * warning: use auto when initializing with new to avoid duplicating the
    type name [modernize-use-auto]
  * warning: use nullptr [modernize-use-nullptr]
  * warning: use '= default' to define a trivial default constructor
    [modernize-use-equals-default]
  * [readability-static-accessed-through-instance]
  * missing include files

Signed-off-by: Hiroshi Miura <miurahr@linux.com>