### PR TITLE
CMake build system for VNote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 VNote.pro.user
+CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
+
+## Default Qt5 path
 if(WIN32)
   set(Qt5_DIR "c:/Qt/Qt5.9.7/5.9.7/msvc2017_64/lib/cmake/Qt5/" CACHE PATH "directory where Qt5Config.cmake exists.")
 elseif(APPLE)
   set(Qt5_DIR "/usr/local/Cellar/qt/5.9.7/clang_64/lib/cmake/Qt5/" CACHE PATH "directory where Qt5Config.cmake exists.")
 else()
-  set(Qt5_DIR "$ENV{HOME}/Qt5.9.7/5.9.7/gcc_64/lib/cmake/Qt5/" CACHE PATH "directory where Qt5Config.cmake exists.")
+  set(Qt5_DIR "" CACHE PATH "directory where Qt5Config.cmake exists.")
 endif()
+
 find_package(Qt5 COMPONENTS Core Gui Network PrintSupport WebChannel WebEngine
              WebEngineWidgets Positioning Svg Widgets LinguistTools
              REQUIRED NO_DEFAULT_PATH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,80 @@
+cmake_minimum_required (VERSION 3.13)
+project(VNote
+        VERSION 2.2.0
+        DESCRIPTION "VNote is a markdown note taking application"
+        HOMEPAGE_URL "https://tamlok.github.io/vnote"
+        LANGUAGES C CXX)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+## Qt5 configurations
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+set(Qt5_DIR "$ENV{HOME}/Qt5.9.7/5.9.7/gcc_64/lib/cmake/Qt5/" CACHE PATH "directory where Qt5Config.cmake exists.")
+find_package(Qt5 COMPONENTS Core Gui Network PrintSupport WebChannel WebEngine
+             WebEngineWidgets Positioning Svg Widgets LinguistTools
+             REQUIRED NO_DEFAULT_PATH)
+## hoedown library
+add_library(hoedown STATIC
+            hoedown/src/autolink.c hoedown/src/document.c  hoedown/src/html.c hoedown/src/html_smartypants.c
+            hoedown/src/version.c hoedown/src/buffer.c hoedown/src/escape.c hoedown/src/html_blocks.c
+            hoedown/src/stack.c )
+target_link_libraries(hoedown PRIVATE Qt5::Core Qt5::Gui)
+## peg-highlight library
+add_library(peg-highlight STATIC peg-highlight/pmh_parser.c peg-highlight/pmh_styleparser.c)
+target_link_libraries(peg-highlight PRIVATE Qt5::Core Qt5::Gui)
+## project sources
+add_subdirectory(src)
+
+option(CMake_RUN_CLANG_TIDY "Run clang-tidy with the compiler." OFF)
+if(CMake_RUN_CLANG_TIDY)
+  if(CMake_SOURCE_DIR STREQUAL CMake_BINARY_DIR)
+    message(FATAL_ERROR "CMake_RUN_CLANG_TIDY requires an out-of-source build!")
+  endif()
+  find_program(CLANG_TIDY_COMMAND NAMES clang-tidy)
+  if(NOT CLANG_TIDY_COMMAND)
+    message(WARNING "CMake_RUN_CLANG_TIDY is ON but clang-tidy is not found!")
+    set(CMAKE_CXX_CLANG_TIDY "" CACHE STRING "" FORCE)
+  else()
+    set(CLANG_TIDY_CHECKS "-*,modernize-*")
+    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND};-checks=${CLANG_TIDY_CHECKS};-header-filter='${CMAKE_SOURCE_DIR}/src/*'")
+  endif()
+
+  # Create a preprocessor definition that depends on .clang-tidy content so
+  # the compile command will change when .clang-tidy changes.  This ensures
+  # that a subsequent build re-runs clang-tidy on all sources even if they
+  # do not otherwise need to be recompiled.  Nothing actually uses this
+  # definition.  We add it to targets on which we run clang-tidy just to
+  # get the build dependency on the .clang-tidy file.
+  file(SHA1 ${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy clang_tidy_sha1)
+  set(CLANG_TIDY_DEFINITIONS "CLANG_TIDY_SHA1=${clang_tidy_sha1}")
+  unset(clang_tidy_sha1)
+
+endif()
+configure_file(.clang-tidy .clang-tidy COPYONLY)
+
+option(CMake_RUN_IWYU "Run include-what-you-use with the compiler." OFF)
+if(CMake_RUN_IWYU)
+  find_program(IWYU_COMMAND NAMES include-what-you-use iwyu)
+  if(NOT IWYU_COMMAND)
+    message(WARNING "CMake_RUN_IWYU is ON but include-what-you-use is not found!")
+  else()
+    set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE
+      "${IWYU_COMMAND};-Xiwyu;--mapping_file=${CMake_SOURCE_DIR}/Utilities/IWYU/mapping.imp;-w")
+    list(APPEND CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${CMake_IWYU_OPTIONS})
+  endif()
+endif()
+
+# Clazy is a Qt oriented code checker based on clang framework. Krazy's little brother.
+set(CMake_RUN_CLAZY OFF CACHE BOOL "Add clazy check for builds")
+if(ENABLE_CLAZY)
+  find_program(CLAZY_EXECUTABLE NAMES clazy PATHS /usr/local/llvm/bin /usr/local/bin /opt/clazy/bin)
+  if(CLAZY_EXECUTABLE)
+    message(STATUS "clazy found: ${CLAZY_EXECUTABLE}")
+  else()
+    message(AUTHOR_WARNING "clazy not found.")
+  endif()
+endif()
+
+# vim: ts=2 sw=2 sts=2 et

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required (VERSION 3.12)
 project(VNote
         VERSION 2.2.0
         DESCRIPTION "VNote is a markdown note taking application"
@@ -11,7 +11,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
-set(Qt5_DIR "$ENV{HOME}/Qt5.9.7/5.9.7/gcc_64/lib/cmake/Qt5/" CACHE PATH "directory where Qt5Config.cmake exists.")
+if(WIN32)
+  set(Qt5_DIR "c:/Qt/Qt5.9.7/5.9.7/msvc2017_64/lib/cmake/Qt5/" CACHE PATH "directory where Qt5Config.cmake exists.")
+elseif(APPLE)
+  set(Qt5_DIR "/usr/local/Cellar/qt/5.9.7/clang_64/lib/cmake/Qt5/" CACHE PATH "directory where Qt5Config.cmake exists.")
+else()
+  set(Qt5_DIR "$ENV{HOME}/Qt5.9.7/5.9.7/gcc_64/lib/cmake/Qt5/" CACHE PATH "directory where Qt5Config.cmake exists.")
+endif()
 find_package(Qt5 COMPONENTS Core Gui Network PrintSupport WebChannel WebEngine
              WebEngineWidgets Positioning Svg Widgets LinguistTools
              REQUIRED NO_DEFAULT_PATH)
@@ -24,6 +30,7 @@ target_link_libraries(hoedown PRIVATE Qt5::Core Qt5::Gui)
 ## peg-highlight library
 add_library(peg-highlight STATIC peg-highlight/pmh_parser.c peg-highlight/pmh_styleparser.c)
 target_link_libraries(peg-highlight PRIVATE Qt5::Core Qt5::Gui)
+
 ## project sources
 add_subdirectory(src)
 
@@ -52,7 +59,6 @@ if(CMake_RUN_CLANG_TIDY)
   unset(clang_tidy_sha1)
 
 endif()
-configure_file(.clang-tidy .clang-tidy COPYONLY)
 
 option(CMake_RUN_IWYU "Run include-what-you-use with the compiler." OFF)
 if(CMake_RUN_IWYU)
@@ -76,5 +82,6 @@ if(ENABLE_CLAZY)
     message(AUTHOR_WARNING "clazy not found.")
   endif()
 endif()
+
 
 # vim: ts=2 sw=2 sts=2 et

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,17 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "inheritEnvironments": [
+        "msvc_x64_x64"
+      ],
+      "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+      "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+      "cmakeCommandArgs": "-DQt5_DIR=c:\\Qt\\Qt5.9.7\\5.9.7\\msvc2017_64\\lib\\cmake\\Qt5\\",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": ""
+    }
+  ]
+}

--- a/changes.md
+++ b/changes.md
@@ -6,6 +6,27 @@
     - Allow to disable smart table;
 - Update to Qt 5.9.7 in CI in Linux;
 - Add user track logics for users counting;
+- Add CMake build system;
+    - Support multiple packaging genration;
+      - QtIFW GUI installer
+      - Debian package
+      - RPM package
+      - AppImage
+      - Tar.gz package
+      - ZIP package
+      - Windows Nullsoft installer
+      - Windows NuGet package
+      - Mac OS X dmg package
+    - Support staic code checkers;
+      - clang-tidy
+      - crazy
+      - include-what-you-see
+    - Support modern IDEs;
+      - Microsoft Visual Studio 2017
+      - JetBrains CLion
+      - QtCreator
+      - XCode
+      - VSCode
 
 ## v2.2
 - Editor

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,207 @@
+add_executable(VNote main.cpp
+    vmainwindow.cpp
+               vdirectorytree.cpp
+               vnote.cpp
+               vnotebook.cpp
+               dialog/vnewdirdialog.cpp
+               vconfigmanager.cpp
+               vfilelist.cpp
+               dialog/vnewfiledialog.cpp
+               vedit.cpp
+               vdocument.cpp
+               utils/vutils.cpp
+               vpreviewpage.cpp
+               vstyleparser.cpp
+               dialog/vnewnotebookdialog.cpp
+               vmarkdownconverter.cpp
+               dialog/vnotebookinfodialog.cpp
+               dialog/vdirinfodialog.cpp
+               dialog/vfileinfodialog.cpp
+               veditoperations.cpp
+               vmdeditoperations.cpp
+               dialog/vinsertimagedialog.cpp
+               vdownloader.cpp
+               veditarea.cpp
+               veditwindow.cpp
+               vedittab.cpp
+               voutline.cpp
+               vsingleinstanceguard.cpp
+               vdirectory.cpp
+               vfile.cpp
+               vnotebookselector.cpp
+               vnofocusitemdelegate.cpp
+               vmdedit.cpp
+               dialog/vfindreplacedialog.cpp
+               dialog/vsettingsdialog.cpp
+               dialog/vdeletenotebookdialog.cpp
+               dialog/vselectdialog.cpp
+               vcaptain.cpp
+               vopenedlistmenu.cpp
+               vnavigationmode.cpp
+               vorphanfile.cpp
+               vcodeblockhighlighthelper.cpp
+               vwebview.cpp
+               vmdtab.cpp
+               vhtmltab.cpp
+               utils/vvim.cpp
+               utils/veditutils.cpp
+               vvimindicator.cpp
+               vbuttonwithwidget.cpp
+               vtabindicator.cpp
+               dialog/vupdater.cpp
+               dialog/vorphanfileinfodialog.cpp
+               vtextblockdata.cpp
+               utils/vpreviewutils.cpp
+               dialog/vconfirmdeletiondialog.cpp
+               vnotefile.cpp
+               vattachmentlist.cpp
+               dialog/vsortdialog.cpp
+               vfilesessioninfo.cpp
+               vtableofcontent.cpp
+               utils/vmetawordmanager.cpp
+               vmetawordlineedit.cpp
+               dialog/vinsertlinkdialog.cpp
+               vplaintextedit.cpp
+               vimageresourcemanager.cpp
+               vlinenumberarea.cpp
+               veditor.cpp
+               vmdeditor.cpp
+               veditconfig.cpp
+               vpreviewmanager.cpp
+               vimageresourcemanager2.cpp
+               vtextdocumentlayout.cpp
+               vtextedit.cpp
+               vsnippetlist.cpp
+               vsnippet.cpp
+               dialog/veditsnippetdialog.cpp
+               utils/vimnavigationforwidget.cpp
+               vtoolbox.cpp
+               vinsertselector.cpp
+               utils/vclipboardutils.cpp
+               vpalette.cpp
+               vbuttonmenuitem.cpp
+               utils/viconutils.cpp
+               lineeditdelegate.cpp
+               dialog/vtipsdialog.cpp
+               dialog/vcopytextashtmldialog.cpp
+               vwaitingwidget.cpp
+               utils/vwebutils.cpp
+               vlineedit.cpp
+               vcart.cpp
+               vvimcmdlineedit.cpp
+               vlistwidget.cpp
+               vsimplesearchinput.cpp
+               vstyleditemdelegate.cpp
+               vtreewidget.cpp
+               dialog/vexportdialog.cpp
+               vexporter.cpp
+               vsearcher.cpp
+               vsearch.cpp
+               vsearchresulttree.cpp
+               vsearchengine.cpp
+               vuniversalentry.cpp
+               vlistwidgetdoublerows.cpp
+               vdoublerowitemwidget.cpp
+               vsearchue.cpp
+               voutlineue.cpp
+               vhelpue.cpp
+               vlistfolderue.cpp
+               dialog/vfixnotebookdialog.cpp
+               vplantumlhelper.cpp
+               vgraphvizhelper.cpp
+               vlivepreviewhelper.cpp
+               vmathjaxpreviewhelper.cpp
+               vmathjaxwebdocument.cpp
+               vmathjaxinplacepreviewhelper.cpp
+               vhistorylist.cpp
+               vexplorer.cpp
+               vlistue.cpp
+               vuetitlecontentpanel.cpp
+               utils/vprocessutils.cpp
+               vtagpanel.cpp
+               valltagspanel.cpp
+               vtaglabel.cpp
+               vtagexplorer.cpp
+               pegmarkdownhighlighter.cpp
+               pegparser.cpp
+               peghighlighterresult.cpp
+               vtexteditcompleter.cpp
+               utils/vkeyboardlayoutmanager.cpp
+               dialog/vkeyboardlayoutmappingdialog.cpp
+               vfilelistwidget.cpp
+               widgets/vcombobox.cpp
+               vtablehelper.cpp
+               vtable.cpp
+               dialog/vinserttabledialog.cpp
+               isearchengine.cpp
+               iuniversalentry.cpp
+               vnote.qrc translations.qrc)
+
+# Qt5 libraries
+target_link_libraries(VNote PRIVATE Qt5::Core Qt5::WebEngine Qt5::WebEngineWidgets
+                      Qt5::Network Qt5::PrintSupport Qt5::WebChannel Qt5::Widgets
+                      Qt5::PrintSupport Qt5::Svg)
+set_property(TARGET VNote PROPERTY AUTORCC_OPTIONS "--compress;9")
+
+# Thirdparty libraries
+target_include_directories(VNote PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/peg-highlight ${CMAKE_SOURCE_DIR}/hoedown)
+target_link_libraries(VNote PRIVATE peg-highlight hoedown)
+
+# Compile options
+if(GCC_VERSION VERSION_GREATER_EQUAL 8.0)
+  target_compile_options(VNote PRIVATE "-Wno-class-memaccess")
+endif()
+
+## INSTALLS
+install(TARGETS VNote RUNTIME DESTINATION bin)
+install(FILES translations/vnote_zh_CN.qm translations/vnote_ja.qm DESTINATION translations )
+
+if(UNIX AND NOT DARWIN)
+    set(desktop.path applications)
+    set(desktop.files vnote.desktop)
+
+    set(icon16.path icons/hicolor/16x16/apps)
+    set(icon16.files resources/icons/16x16/vnote.png)
+
+    set(icon32.path icons/hicolor/32x32/apps)
+    set(icon32.files resources/icons/32x32/vnote.png)
+
+    set(icon48.path icons/hicolor/48x48/apps)
+    set(icon48.files resources/icons/48x48/vnote.png)
+
+    set(icon64.path icons/hicolor/64x64/apps)
+    set(icon64.files resources/icons/64x64/vnote.png)
+
+    set(icon128.path icons/hicolor/128x128/apps)
+    set(icon128.files resources/icons/128x128/vnote.png)
+
+    set(icon256.path icons/hicolor/256x256/apps)
+    set(icon256.files resources/icons/256x256/vnote.png)
+
+    set(iconsvg.path icons/hicolor/scalable/apps)
+    set(iconsvg.files resources/icons/vnote.svg)
+
+    foreach(items IN ITEMS desktop icon16 icon32 icon48 icon64 icon128 icon256 iconsvg)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${${items}.files}
+                DESTINATION share/${${items}.path}
+                PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+    endforeach()
+    install(FILES ${CMAKE_SOURCE_DIR}/LICENSE
+        DESTINATION share/doc/vnote/
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+        RENAME copyright)
+elseif(DARWIN)
+    set(MACOSX_BUNDLE_BUNDLE_NAME "VNote")
+    set(MACOSX_BUNDLE_BUNDLE_GUI_IDENTIFIER "com.tamlok.VNote")
+    set(MACOSX_BUNDLE_ICON_FILE ${CMAKE_SOURCE_DIR}/src/resources/icons/vnote.icns)
+    set(MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+    set(MACOSX_BUNDLE_LONG_VERSION_STRING ${MACOSX_BUNDLE_BUNDLE_VERSION})
+    # Set short version independent with project version to be able to increment independendently.
+    math(EXPR SHORT_VERSION_MAJOR "${PROJECT_VERSION_MAJOR} * 100 + ${PROJECT_VERSION_MINOR}")
+    set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${SHORT_VERSION_MAJOR}.${PROJECT_VERSION_PATCH}.0")
+    set(MACOSX_BUNDLE_EXECUTABLE_NAME "VNote")
+    set(MACOSX_BUNDLE_COPYRIGHT "Distributed under MIT license. Copyright 2016-2019 Le Tan")
+    set(MACOSX_BUNDLE_INFO_STRING "VNote is a note-taking application that knows programmers and Markdown better. Distributed under MIT license. Copyright 2017 Le Tan")
+
+    set_source_files_properties(${MACOSX_BUNDLE_ICON_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(VNote main.cpp
-    vmainwindow.cpp
+               vmainwindow.cpp
                vdirectorytree.cpp
                vnote.cpp
                vnotebook.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -205,3 +205,5 @@ elseif(DARWIN)
 
     set_source_files_properties(${MACOSX_BUNDLE_ICON_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/Packaging.cmake)

--- a/src/CPackLinuxDeployQt.cmake.in
+++ b/src/CPackLinuxDeployQt.cmake.in
@@ -1,0 +1,8 @@
+execute_process(COMMAND ${CMAKE_MAKE_PROGRAM} DESTDIR=${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage install
+                WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+execute_process(COMMAND "${LINUXDEPLOYQT_EXECUTABLE}" ${CMAKE_CURRENT_SOURCE_DIR}/Linux/External/AppImage${CMAKE_INSTALL_PREFIX}/share/applications/vnote.desktop -bundle-non-qt-libs -qmake=${_qmake_executable}
+                # hot fix for a known issue for libnss3 and libnssutils3.
+                COMMAND ${CMAKE_COMMAND} -E copy_directory ${NSS3_PLUGIN_PATH} ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage${CMAKE_INSTALL_PREFIX}/lib/
+                COMMAND "${LINUXDEPLOYQT_EXECUTABLE}"  ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage${CMAKE_INSTALL_PREFIX}/share/applications/vnote.desktop -appimage -qmake=${_qmake_executable}
+                 WORKING_DIRECTORY ${CPACK_PACKAGE_DIRECTORY}
+                )

--- a/src/CPackLinuxDeployQt.cmake.in
+++ b/src/CPackLinuxDeployQt.cmake.in
@@ -1,6 +1,6 @@
 execute_process(COMMAND ${CMAKE_MAKE_PROGRAM} DESTDIR=${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage install
                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-execute_process(COMMAND "${LINUXDEPLOYQT_EXECUTABLE}" ${CMAKE_CURRENT_SOURCE_DIR}/Linux/External/AppImage${CMAKE_INSTALL_PREFIX}/share/applications/vnote.desktop -bundle-non-qt-libs -qmake=${_qmake_executable}
+execute_process(COMMAND "${LINUXDEPLOYQT_EXECUTABLE}" ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage${CMAKE_INSTALL_PREFIX}/share/applications/vnote.desktop -bundle-non-qt-libs -qmake=${_qmake_executable}
                 # hot fix for a known issue for libnss3 and libnssutils3.
                 COMMAND ${CMAKE_COMMAND} -E copy_directory ${NSS3_PLUGIN_PATH} ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage${CMAKE_INSTALL_PREFIX}/lib/
                 COMMAND "${LINUXDEPLOYQT_EXECUTABLE}"  ${CPACK_PACKAGE_DIRECTORY}/_CPack_Packages/Linux/External/AppImage${CMAKE_INSTALL_PREFIX}/share/applications/vnote.desktop -appimage -qmake=${_qmake_executable}

--- a/src/Packaging.cmake
+++ b/src/Packaging.cmake
@@ -1,0 +1,179 @@
+
+find_package(Qt5Core REQUIRED)
+get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)
+get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
+find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
+find_program(LINUXDEPLOYQT_EXECUTABLE linuxdeployqt HINTS "${_qt_bin_dir}")
+find_program(MACDEPLOYQT_EXECUTABLE macdeployqt HINTS "${_qt_bin_dir}")
+find_program(MACDEPLOYQTFIX_EXECUTABLE macdeployqtfix.py HINTS "${_qt_bin_dir}")
+find_package(Python)
+
+mark_as_advanced(WINDEPLOYQT_EXECUTABLE LINUXDEPLOYQT_EXECUTABLE)
+mark_as_advanced(MACDEPLOYQT_EXECUTABLE MACDEPLOYQTFIX_EXECUTABLE)
+
+function(linuxdeployqt destdir desktopfile)
+    add_custom_command(TARGET bundle POST_BUILD
+                       COMMAND make DESTDIR=${destdir} install
+                       COMMAND "${LINUXDEPLOYQT_EXECUTABLE}" ${destdir}/${CMAKE_INSTALL_PREFIX}/${desktopfile} -bundle-non-qt-libs
+                               -qmake=${_qmake_executable}
+                               #-exclude-libs="libnss3,libnssutil3"
+                       # hot fix for a known issue for libnss3 and libnssutils3.
+                       COMMAND ${CMAKE_COMMAND} -E copy_directory /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}/nss
+                                                                  ${destdir}/${CMAKE_INSTALL_PREFIX}/lib/
+                       COMMAND "${LINUXDEPLOYQT_EXECUTABLE}"  ${destdir}/${CMAKE_INSTALL_PREFIX}/${desktopfile}
+                               -appimage -qmake=${_qmake_executable}
+                               # -exclude-libs="libnss3,libnssutil3"
+                       COMMAND ${CMAKE_COMMAND} -E rename VNote-x86_64.AppImage packaging/VNote-x86_64.AppImage
+                       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+endfunction()
+
+function(windeployqt target)
+    add_custom_command(TARGET ${target} POST_BUILD
+                       COMMAND "${CMAKE_COMMAND}" -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/winqt/"
+                       COMMAND "${CMAKE_COMMAND}" -E
+                               env PATH="${_qt_bin_dir}" "${WINDEPLOYQT_EXECUTABLE}"
+                               --verbose 0
+                               --no-compiler-runtime
+                               --no-angle
+                               --no-opengl-sw
+                               --dir "${CMAKE_CURRENT_BINARY_DIR}/winqt/"
+                               ${target}.exe
+                       COMMENT "Deploying Qt..."
+	)
+	install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/winqt/" DESTINATION bin)
+
+    set(CMAKE_INSTALL_UCRT_LIBRARIES TRUE)
+    include(InstallRequiredSystemLibraries)
+endfunction()
+
+function(macdeployqt target)
+    add_custom_command(TARGET bundle POST_BUILD
+                       COMMAND "${MACDEPLOYQT_EXECUTABLE}"
+                           \"$<TARGET_FILE_DIR:${target}>/../..\"
+                           -always-overwrite
+                       COMMAND ${Python_EXECUTABLE} "${MACDEPLOYQTFIX_EXECUTABLE}"
+                           \"$<TARGET_FILE_DIR:${target}>/Contents/MacOS/VNote\"
+                           ${qt_bin_dir}/../
+                       COMMAND "${MACDEPLOYQT_EXECUTABLE}"
+                           \"$<TARGET_FILE_DIR:${target}>/Contents/Frameworks/QtWebEngineCore.framework/Versions/5/Helpers/QtWebEngineProcess.app
+                       COMMAND ${Python_EXECUTABLE} "${MACDEPLOYQTFIX_EXECUTABLE}"
+                           \"$<TARGET_FILE_DIR:${target}>/Contents/Frameworks/QtWebEngineCore.framework/Versions/5/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
+                           ${qt_bin_dir}/../
+                       COMMENT "Deploying Qt..."
+    )
+endfunction()
+
+set(CPACK_PACKAGE_VENDOR "Le Tan")
+set(CPACK_PACKAGE_NAME "vnote")
+set(CPACK_PACKAGE_CONTACT "Le Tan <tamlokveer@gmail.com>")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${PROJECT_DESCRIPTION}")
+set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/README.md")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
+set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "vnote")
+set(CPACK_PACKAGE_DIRECTORY "${CMAKE_BINARY_DIR}/packaging")
+
+# set human names to exetuables
+set(CPACK_PACKAGE_EXECUTABLES "VNote")
+set(CPACK_CREATE_DESKTOP_LINKS "VNote")
+set(CPACK_STRIP_FILES TRUE)
+
+#------------------------------------------------------------------------------
+# include CPack, so we get target for packages
+set(CPACK_OUTPUT_CONFIG_FILE "${CMAKE_BINARY_DIR}/BundleConfig.cmake")
+
+add_custom_target(bundle
+                  COMMAND ${CMAKE_CPACK_COMMAND} "--config" "${CMAKE_BINARY_DIR}/BundleConfig.cmake"
+                  COMMENT "Running CPACK. Please wait..."
+                  DEPENDS VNote)
+if(WIN32 AND NOT UNIX)
+    #--------------------------------------------------------------------------
+    # Windows specific
+    set(CPACK_GENERATOR "ZIP")
+    message(STATUS "Package generation - Windows")
+    message(STATUS "   + ZIP                                  YES ")
+    
+    set(PACKAGE_ICON "${CMAKE_SOURCE_DIR}/src/resources/icons/vnote.ico")
+
+    # NSIS windows installer
+    find_program(NSIS_PATH nsis PATH_SUFFIXES nsis)
+    if(NSIS_PATH)
+        set(CPACK_GENERATOR "${CPACK_GENERATOR};NSIS")
+        message(STATUS "   + NSIS                                 YES ")
+
+        set(CPACK_NSIS_DISPLAY_NAME ${CPACK_PACKAGE_NAME})
+        # Icon of the installer
+        file(TO_NATIVE_PATH "${PACKAGE_ICON}" CPACK_NSIS_MUI_ICON)
+        file(TO_NATIVE_PATH "${PACKAGE_ICON}" CPACK_NSIS_MUI_HEADERIMAGE_BITMAP)
+        set(CPACK_NSIS_CONTACT "${CPACK_PACKAGE_CONTACT}")
+        set(CPACK_NSIS_MODIFY_PATH ON)
+    else()
+        message(STATUS "   + NSIS                                 NO ")
+    endif()
+
+    # NuGet package
+    find_program(NUGET_EXECUTABLE nuget)
+    if(NUGET_EXECUTABLE)
+        set(CPACK_GENERATOR "${CPACK_GENERATOR};NuGET")
+        message(STATUS "   + NuGET                               YES ")
+        set(CPACK_NUGET_PACKAGE_NAME "VNote")
+    else()
+        message(STATUS "   + NuGET                                NO ")
+    endif()
+
+    windeployqt(VNote)
+
+elseif(APPLE)
+    #--------------------------------------------------------------------------
+    # Apple specific
+    message(STATUS "Package generation - Mac OS X")
+    message(STATUS "   + TBZ2                                 YES ")
+    message(STATUS "   + DragNDrop                            YES ")
+
+    set(CPACK_GENERATOR "TBZ2;DragNDrop")
+    set(CPACK_PACKAGING_INSTALL_PREFIX "/")
+    set(CPACK_DMG_VOLUME_NAME "VNote")
+    # set(CPACK_DMG_DS_STORE_SETUP_SCRIPT "${CMAKE_SOURCE_DIR}/DS_Store.scpt")
+    set(CPACK_DMG_BACKGROUND_IMAGE "${CMAKE_SOURCE_DIR}/src/resources/icons/vnote.png")
+    set(CPACK_OSX_PACKAGE_VERSION "10.6") #min package version
+
+    macdeployqt(VNote)
+
+else()
+    #-----------------------------------------------------------------------------
+    # Linux specific
+    set(CPACK_GENERATOR "DEB;TBZ2;TXZ")
+    message(STATUS "Package generation - UNIX")
+    message(STATUS "   + DEB                                  YES ")
+    message(STATUS "   + TBZ2                                 YES ")
+    message(STATUS "   + TXZ                                  YES ")
+
+    find_program(RPMBUILD_PATH rpmbuild)
+    if(RPMBUILD_PATH)
+        message(STATUS "   + RPM                                  YES ")
+        set(CPACK_GENERATOR "${CPACK_GENERATOR};RPM")
+        set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+    else()
+        message(STATUS "   + RPM                                  NO ")
+    endif()
+
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+    set(CPACK_DEBIAN_PACKAGE_CONTROL_STRICT_PERMISSION TRUE)
+    set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://tamlok.github.io/vnote")
+    set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)
+
+    if(LINUXDEPLOYQT_EXECUTABLE)
+        message(STATUS "   + AppImage                             YES ")
+        linuxdeployqt("${CPACK_PACKAGE_DIRECTORY}/_AppDir" "share/applications/vnote.desktop")
+    else()
+        message(STATUS "   + AppImage                              NO ")
+    endif()
+
+   # set package icon
+    set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/src/resources/icons/vnote.png")
+endif()
+
+include(CPack)

--- a/src/isearchengine.cpp
+++ b/src/isearchengine.cpp
@@ -1,0 +1,1 @@
+#include "isearchengine.h"

--- a/src/iuniversalentry.cpp
+++ b/src/iuniversalentry.cpp
@@ -1,0 +1,1 @@
+#include "iuniversalentry.h"


### PR DESCRIPTION
CMake is a cross-platform free and open-source software (meta) build system for managing the build process of software using a compiler-independent method. 
Recent IDEs such as QtCreator, JetBrains CLion, VSCode, Visual Studio 2017, XCode supports CMake.

Here is a proposal to add CMake build script to VNote project.

Features
======

* Support building VNote project on Linux(GCC, CLANG), OS X(Apple Clang and Xcode) and Windows(MSVC).

* Support packaging.  DEB, RPM, TBZ2 and AppImage on Linux, DMG on Mac OS X, and Installer(NullSoft Installer System) and ZIP archive on WIndows.

* Support Qt Installer Framework (IFW)  to produce GUI installer for Linux, Mac OS X and Windows.

* Support statistic code analyzer;  clang-tidy, include-what-you-use and crazy check.

* Support and tested IDEs;  QtCreator, JetBrains CLion, Visual Studio 2017. 

Benefit
=======

* We can utilize modern IDEs to coding and refactoring.

* Improve packaging.

* It can co-exist with current QMake scripts.

Limitations and known issues
========================

* Qt 5.9 now support with MSVS2017(64bit), MSVS2015(32bit, 64bit), mingw-w64(32bit) on windows, and MSVC2017 only support CMake as IDE's native build system.  So we need to build 32bit binary using CMake with command line using VisualC++ bundled with MSVS2015.

* No test on Mac OS X (Because I don't have).

* Build exe successful but fails to build AppImage packaging in QtCreator on Linux

HOWTO BUILD
===========

* On Ubuntu Linux Bionic;

```bash
$ sudo apt-get install -y cmake g++ qt5-default
$ mkdir cmake-build-debug
$ cd cmake-build-debug
$ cmake  -DQt5_DIR=/usr/lib/x86_64-linux-gnu/cmake/Qt5/ /where/to/vnote/source/dir/
$ make -j3
$ make bundle
```

On Windows

* Install Qt5 and Visual Studio 2017 with CMake support
* Edit `CMakeSettings.json` for Qt5 path.
* Open CMakeLists.txt from VS2017.
* Run build all
* Run build `src/bundle` for packaging.

On Windows command line

```CMD
C:> mkdir build
C:> cd build
C:\build> cmake -G "Microsoft Visual Studio 2017 15 Win64"  -DQt5_DIR=C:\Qt\Qt5.9.7\5.9.7\msvc2017_64\lib\cmake\Qt5\ C:\where\vnote\source\
C:\build> cmake --build . --target all  --config Debug
C:\build> cmake --build . --target bundle
```

When running clang-tidy code checker, please configure `cmake -DCMake_RUN_CLANG_TIDY=ON ..`
also  `cmake -DCMake_RUN_CLAZY =ON ..` enables crazy checker and `-DCMake_RUN_IWYU=ON` enables `include-what-you-use `.