### PR TITLE
CMake: Update packaging script

### DIFF
--- a/.travis_linux.sh
+++ b/.travis_linux.sh
@@ -8,9 +8,6 @@ if [ -z ${TRAVIS_COMMIT+x} ]; then
     exit 1
 fi
 
-# Install qt5ct for a native look
-sudo add-apt-repository ppa:hda-me/qt5ct -y
-
 # Install qt5.9
 sudo add-apt-repository ppa:george-edison55/cmake-3.x -y
 sudo add-apt-repository ppa:beineri/opt-qt597-trusty -y
@@ -18,14 +15,12 @@ sudo apt-get update -qq
 sudo apt-get -y install qt59base qt59webengine qt59webchannel qt59svg qt59location qt59tools qt59translations
 source /opt/qt*/bin/qt*-env.sh
 
-# Install qt5ct for a native look
-sudo apt-get -y install qt5ct
-
-tree /usr/lib/x86_64-linux-gnu/qt5/plugins
-
-sudo cp -r -n /usr/lib/x86_64-linux-gnu/qt5/plugins/platformthemes /opt/qt*/plugins/
-
-tree /opt/qt*/plugins/
+# Compile qt5ct
+wget -c https://jaist.dl.sourceforge.net/project/qt5ct/qt5ct-0.37.tar.bz2
+tar xf qt5ct-0.*.tar.bz2
+cd qt5ct-0.*/
+QT_SELECT=5 qmake
+make -j$(nproc) && sudo make install
 
 # Compile newer version fcitx-qt5
 sudo apt-get -y install fcitx-libs-dev libgl1-mesa-dev bison
@@ -88,13 +83,13 @@ cp vnote-utils.git/linuxdeployqt-continuous-x86_64.AppImage ./linuxdeployqt-cont
 # wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
 chmod a+x linuxdeployqt*.AppImage
 unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-./linuxdeployqt*.AppImage ./dist/usr/share/applications/*.desktop -bundle-non-qt-libs -exclude-libs=libnss3,libnssutil3 -extra-plugins=platformthemes/libqt5ct.so
+./linuxdeployqt*.AppImage ./dist/usr/share/applications/*.desktop -bundle-non-qt-libs -exclude-libs=libnss3,libnssutil3 -extra-plugins=platformthemes/libqt5ct.so,styles/libqt5ct-style.so
 
 # Copy translations
 cp /opt/qt59/translations/*_zh_CN.qm ./dist/usr/translations/
 
 # Package it for the second time.
-./linuxdeployqt*.AppImage ./dist/usr/share/applications/*.desktop -appimage -exclude-libs=libnss3,libnssutil3 -extra-plugins=platformthemes/libqt5ct.so
+./linuxdeployqt*.AppImage ./dist/usr/share/applications/*.desktop -appimage -exclude-libs=libnss3,libnssutil3 -extra-plugins=platformthemes/libqt5ct.so,styles/libqt5ct-style.so
 
 tree dist/
 

--- a/src/Packaging.cmake
+++ b/src/Packaging.cmake
@@ -166,9 +166,12 @@ else()
 
     set(CPACK_GENERATOR "${CPACK_GENERATOR};DEB")
     message(STATUS "   + DEB                                  YES ")
-    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+    # use default, that is an output of `dpkg --print-architecture`
+    #set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
     set(CPACK_DEBIAN_PACKAGE_CONTROL_STRICT_PERMISSION TRUE)
     set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://tamlok.github.io/vnote")
+    # check if dependencies exist in standard path, i.e standard package
+    # ubuntu bionic or later has it.
     find_path(QT5WEBENGINEWIDGET_PATH
               NAMES libQt5WebEngineWidgets.so
               PATHS /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE} /usr/lib
@@ -177,10 +180,11 @@ else()
         set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
     else()
         set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)
-        if(NOT CPACK_DEBIAN_PACKAGE_DEPENDS)
-            set(CPACK_DEBIAN_PACKAGE_DEPENDS   libqt5core5a libqt5gui5 libqt5positioning5 libqt5webenginewidgets5)
-        endif()
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "libqt5core5a, libqt5gui5, libqt5positioning5, libqt5webenginewidgets5")
     endif()
+    set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "graphviz")
+    set(CPACK_DEBIAN_PACKAGE_SUGGESTS "libjs-mathjax")
+    set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
 
     if(LINUXDEPLOYQT_EXECUTABLE)
         message(STATUS "   + AppImage                             YES ")


### PR DESCRIPTION
## Fixed some problems for packaging in CMake

* Fix packaging script for mac  to run `macdeployqt` succesfully.
* Switch packaging  tool from DragNdrop to `macdeployqt -dmg` option.
* Fix Debian packaging dependency value on Linux
* Generate package with Release library binary by detecting compile mode on Windows.

## Limitation

* CMake 3.13  is necessary to build a package on mac OS X.
