### PR TITLE
added theme v_next

### DIFF
--- a/src/resources/themes/v_next/arrow_dropdown.svg
+++ b/src/resources/themes/v_next/arrow_dropdown.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="512px" height="512px" viewBox="0 0 512 512" enable-background="new 0 0 512 512" xml:space="preserve">
+<g>
+	<polygon fill="#333333" points="128,192 256,320 384,192 	"/>
+</g>
+</svg>

--- a/src/resources/themes/v_next/arrow_dropdown_disabled.svg
+++ b/src/resources/themes/v_next/arrow_dropdown_disabled.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="512px" height="512px" viewBox="0 0 512 512" enable-background="new 0 0 512 512" xml:space="preserve">
+<g>
+	<polygon fill="#C0C0C0" points="128,192 256,320 384,192 	"/>
+</g>
+</svg>

--- a/src/resources/themes/v_next/branch_closed.svg
+++ b/src/resources/themes/v_next/branch_closed.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <g transform="rotate(-90 256.00000000000006,256) " id="svg_1">
+   <polygon fill="#333333" id="svg_2" points="128,192 256,320 384,192  "/>
+  </g>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/branch_end.svg
+++ b/src/resources/themes/v_next/branch_end.svg
@@ -1,0 +1,7 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 2</title>
+  <rect stroke="null" fill="#E0E0E0" stroke-width="null" stroke-dasharray="null" stroke-linejoin="null" stroke-linecap="null" x="225.3" y="0.100029" width="51" height="281.537138" id="svg_3"/>
+  <rect fill="#E0E0E0" stroke-width="null" stroke-dasharray="null" stroke-linejoin="null" stroke-linecap="null" x="346.499997" y="116.499998" width="51" height="278.999996" id="svg_6" transform="rotate(90 372,256.00000000000006) " stroke="null"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/branch_more.svg
+++ b/src/resources/themes/v_next/branch_more.svg
@@ -1,0 +1,7 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 2</title>
+  <rect stroke="null" fill="#E0E0E0" stroke-width="null" stroke-dasharray="null" stroke-linejoin="null" stroke-linecap="null" x="225.3" y="0.100029" width="51" height="511.910139" id="svg_3"/>
+  <rect fill="#E0E0E0" stroke-width="null" stroke-dasharray="null" stroke-linejoin="null" stroke-linecap="null" x="346.499997" y="116.499998" width="51" height="278.999996" id="svg_6" transform="rotate(90 372,256.00000000000006) " stroke="null"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/branch_open.svg
+++ b/src/resources/themes/v_next/branch_open.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <g id="svg_1">
+   <polygon fill="#333333" id="svg_2" points="128,192 256,320 384,192  "/>
+  </g>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/checkbox_checked.svg
+++ b/src/resources/themes/v_next/checkbox_checked.svg
@@ -1,0 +1,7 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <rect id="svg_6" fill-opacity="0" height="299" width="299" y="106.5" x="106.5" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="30" stroke="#333333" fill="#000000"/>
+  <path stroke-opacity="0" id="svg_3" d="m126,243.24589l27.93756,-27.94743l76.53449,76.52461l127.58052,-127.54102l27.94743,27.92768l-155.52795,155.50821" stroke-width="5" fill="#333333" stroke="#000000"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/checkbox_checked_disabled.svg
+++ b/src/resources/themes/v_next/checkbox_checked_disabled.svg
@@ -1,0 +1,7 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <rect id="svg_6" fill-opacity="0" height="299" width="299" y="106.5" x="106.5" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="30" stroke="#C0C0C0" fill="#000000"/>
+  <path stroke-opacity="0" id="svg_3" d="m126,243.24589l27.93756,-27.94743l76.53449,76.52461l127.58052,-127.54102l27.94743,27.92768l-155.52795,155.50821" stroke-width="5" fill="#C0C0C0" stroke="#000000"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/checkbox_unchecked.svg
+++ b/src/resources/themes/v_next/checkbox_unchecked.svg
@@ -1,0 +1,6 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <rect id="svg_6" fill-opacity="0" height="299" width="299" y="106.5" x="106.5" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="30" stroke="#333333" fill="#000000"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/checkbox_unchecked_disabled.svg
+++ b/src/resources/themes/v_next/checkbox_unchecked_disabled.svg
@@ -1,0 +1,6 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <rect id="svg_6" fill-opacity="0" height="299" width="299" y="106.5" x="106.5" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="30" stroke="#C0C0C0" fill="#000000"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/close.svg
+++ b/src/resources/themes/v_next/close.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="512px" height="512px" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<path style="fill:#333333" d="M443.6,387.1L312.4,255.4l131.5-130c5.4-5.4,5.4-14.2,0-19.6l-37.4-37.6c-2.6-2.6-6.1-4-9.8-4c-3.7,0-7.2,1.5-9.8,4
+	L256,197.8L124.9,68.3c-2.6-2.6-6.1-4-9.8-4c-3.7,0-7.2,1.5-9.8,4L68,105.9c-5.4,5.4-5.4,14.2,0,19.6l131.5,130L68.4,387.1
+	c-2.6,2.6-4.1,6.1-4.1,9.8c0,3.7,1.4,7.2,4.1,9.8l37.4,37.6c2.7,2.7,6.2,4.1,9.8,4.1c3.5,0,7.1-1.3,9.8-4.1L256,313.1l130.7,131.1
+	c2.7,2.7,6.2,4.1,9.8,4.1c3.5,0,7.1-1.3,9.8-4.1l37.4-37.6c2.6-2.6,4.1-6.1,4.1-9.8C447.7,393.2,446.2,389.7,443.6,387.1z"/>
+</svg>

--- a/src/resources/themes/v_next/close_grey.svg
+++ b/src/resources/themes/v_next/close_grey.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="512px" height="512px" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<path style="fill:#9E9E9E" d="M443.6,387.1L312.4,255.4l131.5-130c5.4-5.4,5.4-14.2,0-19.6l-37.4-37.6c-2.6-2.6-6.1-4-9.8-4c-3.7,0-7.2,1.5-9.8,4
+	L256,197.8L124.9,68.3c-2.6-2.6-6.1-4-9.8-4c-3.7,0-7.2,1.5-9.8,4L68,105.9c-5.4,5.4-5.4,14.2,0,19.6l131.5,130L68.4,387.1
+	c-2.6,2.6-4.1,6.1-4.1,9.8c0,3.7,1.4,7.2,4.1,9.8l37.4,37.6c2.7,2.7,6.2,4.1,9.8,4.1c3.5,0,7.1-1.3,9.8-4.1L256,313.1l130.7,131.1
+	c2.7,2.7,6.2,4.1,9.8,4.1c3.5,0,7.1-1.3,9.8-4.1l37.4-37.6c2.6-2.6,4.1-6.1,4.1-9.8C447.7,393.2,446.2,389.7,443.6,387.1z"/>
+</svg>

--- a/src/resources/themes/v_next/down.svg
+++ b/src/resources/themes/v_next/down.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <g transform="null" id="svg_1">
+   <polygon points="128,192 256,320 384,192  " id="svg_2" fill="#333333"/>
+  </g>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/down_disabled.svg
+++ b/src/resources/themes/v_next/down_disabled.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <g transform="null" id="svg_1">
+   <polygon points="128,192 256,320 384,192  " id="svg_2" fill="#C0C0C0"/>
+  </g>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/float.svg
+++ b/src/resources/themes/v_next/float.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="512px" height="512px" viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<g>
+	<path style="fill:#333333" d="M64,144v304h303.9V144H64z M351.9,432H80V160h271.9V432z"/>
+	<g>
+		<polygon style="fill:#333333" points="448,64 144,64 144,128 160,128 160,80 432,80 432,352 384,352 384,368 448,368 		"/>
+	</g>
+</g>
+</svg>

--- a/src/resources/themes/v_next/left.svg
+++ b/src/resources/themes/v_next/left.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <g transform="rotate(90 255.99999999999997,256.00000000000006) " id="svg_1">
+   <polygon points="128,192 256,320 384,192  " id="svg_2" fill="#333333"/>
+  </g>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/left_disabled.svg
+++ b/src/resources/themes/v_next/left_disabled.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <g transform="rotate(90 255.99999999999997,256.00000000000006) " id="svg_1">
+   <polygon points="128,192 256,320 384,192  " id="svg_2" fill="#C0C0C0"/>
+  </g>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/line.svg
+++ b/src/resources/themes/v_next/line.svg
@@ -1,0 +1,6 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 2</title>
+  <rect stroke="null" id="svg_3" height="510.999989" width="51" y="0.100029" x="225.3" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#E0E0E0"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/menu_checkbox.svg
+++ b/src/resources/themes/v_next/menu_checkbox.svg
@@ -1,0 +1,6 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <path stroke-opacity="0" id="svg_3" d="m126,243.24589l27.93756,-27.94743l76.53449,76.52461l127.58052,-127.54102l27.94743,27.92768l-155.52795,155.50821" stroke-width="5" fill="#333333" stroke="#000000"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/menu_radiobutton.svg
+++ b/src/resources/themes/v_next/menu_radiobutton.svg
@@ -1,0 +1,6 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <circle fill="#333333" stroke="#000000" stroke-width="20" stroke-dasharray="null" stroke-linejoin="null" stroke-linecap="null" stroke-opacity="0" cx="257.00002" cy="256" r="83.2406" id="svg_11"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/radiobutton_checked.svg
+++ b/src/resources/themes/v_next/radiobutton_checked.svg
@@ -1,0 +1,7 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <circle fill="#000000" stroke-width="30" stroke-dasharray="null" stroke-linejoin="null" stroke-linecap="null" fill-opacity="0" cx="256.00001" cy="256.00001" r="142.96561" id="svg_9" stroke="#333333"/>
+  <circle fill="#333333" stroke="#000000" stroke-width="20" stroke-dasharray="null" stroke-linejoin="null" stroke-linecap="null" stroke-opacity="0" cx="256.00002" cy="256" r="83.2406" id="svg_11"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/radiobutton_checked_disabled.svg
+++ b/src/resources/themes/v_next/radiobutton_checked_disabled.svg
@@ -1,0 +1,7 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <circle fill="#000000" stroke-width="30" stroke-dasharray="null" stroke-linejoin="null" stroke-linecap="null" fill-opacity="0" cx="256.00001" cy="256.00001" r="142.96561" id="svg_9" stroke="#C0C0C0"/>
+  <circle fill="#C0C0C0" stroke="#000000" stroke-width="20" stroke-dasharray="null" stroke-linejoin="null" stroke-linecap="null" stroke-opacity="0" cx="256.00002" cy="256" r="83.2406" id="svg_11"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/radiobutton_unchecked.svg
+++ b/src/resources/themes/v_next/radiobutton_unchecked.svg
@@ -1,0 +1,6 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <circle fill="#000000" stroke-width="30" stroke-dasharray="null" stroke-linejoin="null" stroke-linecap="null" fill-opacity="0" cx="256.00001" cy="256.00001" r="142.96561" id="svg_9" stroke="#333333"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/radiobutton_unchecked_disabled.svg
+++ b/src/resources/themes/v_next/radiobutton_unchecked_disabled.svg
@@ -1,0 +1,6 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <circle fill="#000000" stroke-width="30" stroke-dasharray="null" stroke-linejoin="null" stroke-linecap="null" fill-opacity="0" cx="256.00001" cy="256.00001" r="142.96561" id="svg_9" stroke="#C0C0C0"/>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/right.svg
+++ b/src/resources/themes/v_next/right.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <g transform="rotate(-90 256.00000000000006,256) " id="svg_1">
+   <polygon fill="#333333" id="svg_2" points="128,192 256,320 384,192  "/>
+  </g>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/right_disabled.svg
+++ b/src/resources/themes/v_next/right_disabled.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <g transform="rotate(-90 256.00000000000006,256) " id="svg_1">
+   <polygon fill="#C0C0C0" id="svg_2" points="128,192 256,320 384,192  "/>
+  </g>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/up.svg
+++ b/src/resources/themes/v_next/up.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <g transform="rotate(180 255.99999999999997,256) " id="svg_1">
+   <polygon points="128,192 256,320 384,192  " id="svg_2" fill="#333333"/>
+  </g>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/up_disabled.svg
+++ b/src/resources/themes/v_next/up_disabled.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <g>
+  <title>Layer 1</title>
+  <g transform="rotate(180 255.99999999999997,256) " id="svg_1">
+   <polygon points="128,192 256,320 384,192  " id="svg_2" fill="#C0C0C0"/>
+  </g>
+ </g>
+</svg>

--- a/src/resources/themes/v_next/v_next.css
+++ b/src/resources/themes/v_next/v_next.css
@@ -1,0 +1,408 @@
+*,
+*:before,
+*:after {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: "Microsoft YaHei", "Helvetica Neue", "Microsoft YaHei UI", Arial, "Times New Roman", "Hiragino Sans GB", "STHeiti", "WenQuanYi Micro Hei", SimSun, Song, sans-serif;
+    color: #555;
+    line-height: 2em;
+    font-size: 16px;
+    max-width: 800px;
+    margin: 20px auto;
+    padding: 0 10px;
+    background-color: #FFF;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-weight: bold;
+    line-height: 1.2em;
+    margin: 1.2em 0 0.6em 0;
+}
+
+p {
+    display: block;
+    margin: 0 0 1.1em;
+    letter-spacing: 0.04em;
+    /*text-align: justify;*/
+    /*margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;*/
+}
+
+h1 {
+    /*font-size: 41.6px;*/
+    font-size: 2.2em;
+}
+
+h2 {
+    /*font-size: 34.4px;*/
+    font-size: 1.7em;
+}
+
+h3 {
+    /*font-size: 27.2px;*/
+    font-size: 1.4em;
+}
+
+h4 {
+    /*font-size: 20px;*/
+    font-size: 1.2em;
+}
+
+h5 {
+    /*font-size: 18px;*/
+    font-size: 1.08em;
+}
+
+h6 {
+    /*font-size: 16px;*/
+    font-size: 1em;
+}
+
+a {
+    color: #1980e6;
+    text-decoration: none;
+    transition: background-color ease-in-out .15s, color ease-in-out .15s, border-color ease-in-out .15s;
+    -webkit-transition: background-color ease-in-out .15s, color ease-in-out .15s, border-color ease-in-out .15s;
+}
+
+a:hover,
+a:focus {
+    color: #0f4d8a;
+    text-decoration: underline
+}
+
+a:focus {
+    outline: thin dotted;
+    outline: 5px auto -webkit-focus-ring-color;
+    outline-offset: -2px
+}
+
+ul,
+ol {
+    /*line-height: 1.6em;*/
+    /*margin-top: 0;*/
+    /*margin-bottom: 1.1em;*/
+    margin: 0 0 1.4em 1.4em;
+    padding-left: 0;
+}
+
+li {
+    /*line-height: 1.6em;*/
+}
+
+pre, code {
+    font-family: "Source Code Pro","YaHei Consolas Hybrid","Microsoft YaHei Mono",Consolas,monospace;
+}
+
+pre {
+    display: block;
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: nowrap;
+    padding: 0;
+    border: 0;
+    margin: 0 0 10.5px;
+}
+
+code {
+    color: #c7254e;
+    background-color: #f9f2f4;
+    border-radius: 4px;
+    white-space: normal;
+    padding: 2px 4px;
+    font-size: 90%;
+}
+
+pre code {
+    padding: 1em 1em !important;
+    border-radius: 0;
+    white-space: pre;
+    background-color: transparent;
+    line-height: 1.5em;
+}
+
+pre code.markdown-metadata {
+    /*border-left: .5em solid #80CBC4;*/
+    border-left: 0;
+}
+
+aside {
+    display: block;
+    float: right;
+    width: 390px;
+}
+
+blockquote {
+    border-left: 10px solid rgba(102,128,153,0.075);
+    background-color: rgba(102,128,153,0.05);
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+    padding: 10px 15px;
+    margin-left: 0;
+}
+
+blockquote p {
+    /*color: #666;*/
+    margin-bottom: 1.1em;
+    font-size: 1em;
+    font-weight: 300;
+}
+
+blockquote p:last-child {
+    margin-bottom: 0;
+}
+
+hr {
+    margin: 2em 0;
+    border: 0;
+    border-top: 1px solid rgba(102,128,153,0.1);
+    box-sizing: content-box;
+    height: 0;
+    /*display: block;
+    text-align: left;
+    margin: 1em 0;
+    border: none;
+    height: 2px;
+    background: #999;*/
+}
+
+table {
+    margin-bottom: 20px;
+    border-collapse: collapse;
+    max-width: 100%;
+    background-color: transparent;
+    /*padding: 0;
+    border-collapse: collapse;*/
+}
+
+table tr {
+    border-top: 1px solid #ddd;
+    background-color: transparent;
+    margin: 0;
+    padding: 0;
+}
+
+table tr:nth-child(2n) {
+    background-color: #f8f8f8;
+}
+
+table tr th {
+    font-weight: bold;
+    border: 1px solid #ddd;
+    margin: 0;
+    padding: 0.5em;
+    background-color: #f8f8f8;
+}
+
+table tr td {
+    border: 1px solid #ddd;
+    margin: 0;
+    padding: 0.5em;
+}
+
+table tr th :first-child,
+table tr td :first-child {
+    margin-top: 0;
+}
+
+table tr th :last-child,
+table tr td :last-child {
+    margin-bottom: 0;
+}
+
+div.mermaid-diagram {
+    margin: 16px 0px 16px 0px;
+    overflow-y: hidden;
+}
+
+div.flowchart-diagram {
+    padding: 0px 5px 0px 5px;
+    margin: 16px 0px 16px 0px;
+    width: fit-content;
+    overflow: hidden;
+}
+
+div.plantuml-diagram {
+    padding: 5px 5px 0px 5px;
+    margin: 16px 0px 16px 0px;
+    width: fit-content;
+    overflow: hidden;
+}
+
+.img-package {
+    text-align: center;
+}
+
+img.img-center {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+div.img-caption {
+    min-width: 20%;
+    max-width: 80%;
+    display: inline-block;
+    padding: 10px;
+    margin: 0 auto;
+    border-bottom: 1px solid #c0c0c0;
+    color: #6c6c6c;
+    text-align: center;
+    line-height: 1.5;
+}
+
+.emoji_zero,
+.emoji_one,
+.emoji_two,
+.emoji_three,
+.emoji_four,
+.emoji_five,
+.emoji_six,
+.emoji_seven,
+.emoji_eight,
+.emoji_nine {
+    margin-left: 5px;
+    margin-right: 8px;
+}
+
+div.preview-hint {
+    opacity: 0.5;
+    margin-top: 30%;
+    margin-bottom: 30%;
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+
+/* For Highlight.js Line Number */
+
+table.hljs-ln tr {
+    border: none;
+    background-color: transparent;
+}
+
+table.hljs-ln tr td {
+    border: none;
+    background-color: transparent;
+}
+
+table.hljs-ln tr td.hljs-ln-numbers {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+
+    text-align: center;
+    color: #AAA;
+    border-right: 1px solid #CCC;
+    vertical-align: top;
+    padding-right: 5px;
+    white-space: nowrap;
+}
+
+table.hljs-ln tr td.hljs-ln-code {
+    padding-left: 10px;
+}
+
+::-webkit-scrollbar {
+    background-color: #EAEAEA;
+    width: 14px;
+    height: 14px;
+    border: none;
+}
+
+::-webkit-scrollbar-corner {
+    background-color: #EAEAEA;
+}
+
+::-webkit-scrollbar-button {
+    /* This selector affects the styling of both the up & down and left & right buttons of a scrollbar */
+    height: 14px;
+    width: 14px;
+    background-color: #EAEAEA;
+}
+
+::-webkit-scrollbar-button:hover {
+    background-color: #D0D0D0;
+}
+
+::-webkit-scrollbar-button:active {
+    background-color: #B2B2B2;
+}
+
+::-webkit-scrollbar-track {
+    /* This selector affects the styling of the area in the scrollbar between the two buttons */
+    background-color: #EAEAEA;
+}
+
+::-webkit-scrollbar-thumb {
+    /* This selector affects the styling of draggable element of the scollbar */
+    border: none;
+    background-color: #DADADA;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background-color: #D0D0D0;
+}
+
+::-webkit-scrollbar-thumb:active {
+    background-color: #B2B2B2;
+}
+
+::-webkit-scrollbar-button:horizontal:increment {
+    background-image: url(right.svg);
+    background-repeat: no-repeat;
+    background-size: contain;
+}
+
+::-webkit-scrollbar-button:horizontal:decrement {
+    background-image: url(left.svg);
+    background-repeat: no-repeat;
+    background-size: contain;
+}
+
+::-webkit-scrollbar-button:vertical:increment {
+    background-image: url(down.svg);
+    background-repeat: no-repeat;
+    background-size: contain;
+}
+
+::-webkit-scrollbar-button:vertical:decrement {
+    background-image: url(up.svg);
+    background-repeat: no-repeat;
+    background-size: contain;
+}
+
+::selection {
+    background: #1976D2;
+    color: #F5F5F5;
+}
+
+.modal-box {
+    background-color: rgb(234, 234, 234);
+    background-color: rgba(234, 234, 234, 0.95);
+}
+
+span.modal-close {
+    color: #666666;
+}
+
+span.modal-close:hover,
+span.modal-close:focus {
+    color: #2f2f2f;
+}

--- a/src/resources/themes/v_next/v_next.mdhl
+++ b/src/resources/themes/v_next/v_next.mdhl
@@ -1,0 +1,202 @@
+# This is the default markdown styles used for Peg-Markdown-Highlight
+# created by Le Tan(tamlokveer@gmail.com).
+# For a complete description of the syntax, please refer to the original
+# documentation of the style parser
+# [The Syntax of PEG Markdown Highlight Stylesheets](http://hasseg.org/peg-markdown-highlight/docs/stylesheet_syntax.html).
+# VNote adds some styles in the syntax which will be marked [VNote] in the comment.
+#
+# Note: Empty lines within a section is NOT allowed.
+# Note: Do NOT modify this file directly. Copy it and tune your own style!
+
+editor
+# QTextEdit just choose the first available font, so specify the Chinese fonts first
+# Do not use "" to quote the name
+font-family: Hiragino Sans GB, 冬青黑体, Microsoft YaHei, 微软雅黑, Microsoft YaHei UI, WenQuanYi Micro Hei, 文泉驿雅黑, Dengxian, 等线体, STXihei, 华文细黑, Liberation Sans, Droid Sans, NSimSun, 新宋体, SimSun, 宋体, Verdana, Helvetica, sans-serif, Tahoma, Arial, Geneva, Georgia, Times New Roman
+font-size: 12
+foreground: 222222
+background: f5f5f5
+# [VNote] Style for trailing space
+trailing-space: a8a8a8
+# [VNote] Style for line number
+line-number-background: eaeaea
+line-number-foreground: 424242
+# [VNote] Style for selected word highlight
+selected-word-foreground: 222222
+selected-word-background: dfdf00
+# [VNote] Style for searched word highlight
+searched-word-foreground: 222222
+searched-word-background: 4db6ac
+# [VNote] Style for searched word under cursor highlight
+searched-word-cursor-foreground: 222222
+searched-word-cursor-background: 66bb6a
+# [VNote] Style for incremental searched word highlight
+incremental-searched-word-foreground: 222222
+incremental-searched-word-background: ce93d8
+# [VNote] Style for color column in fenced code block
+color-column-background: dd0000
+color-column-foreground: ffff00
+# [VNote] Style for preview image line
+preview-image-line-foreground: 9575cd
+
+editor-selection
+foreground: f5f5f5
+background: 1976d2
+
+editor-current-line
+background: c5cae9
+# [VNote] Vim insert mode cursor line background
+vim-insert-background: c5cae9
+# [VNote] Vim normal mode cursor line background
+vim-normal-background: e0e0e0
+# [VNote] Vim visual mode cursor line background
+vim-visual-background: ffe0b2
+# [VNote] Vim replace mode cursor line background
+vim-replace-background: f8bbd0
+
+H1
+foreground: 222222
+font-style: bold
+font-size: +6
+
+H2
+foreground: 222222
+font-style: bold
+font-size: +5
+
+H3
+foreground: 222222
+font-style: bold
+font-size: +4
+
+H4
+foreground: 222222
+font-style: bold
+font-size: +3
+
+H5
+foreground: 222222
+font-style: bold
+font-size: +2
+
+H6
+foreground: 222222
+font-style: bold
+font-size: +1
+
+HRULE
+foreground: 222222
+background: dac7c9
+
+LIST_BULLET
+foreground: d33682
+font-style: bold
+font-size: +2
+
+LIST_ENUMERATOR
+foreground: 0000ff
+
+LINK
+foreground: 005fff
+
+AUTO_LINK_URL
+foreground: 005fff
+
+AUTO_LINK_EMAIL
+foreground: 005fff
+
+IMAGE
+foreground: 616161
+
+REFERENCE
+foreground: 826200
+
+CODE
+foreground: 8e24aa
+font-family: Consolas, Monaco, Andale Mono, Monospace, Courier New
+
+EMPH
+font-style: italic
+
+STRONG
+font-style: bold
+
+HTML_ENTITY
+foreground: 8900b5
+
+HTML
+foreground: 8900b5
+
+HTMLBLOCK
+foreground: 8900b5
+
+COMMENT
+foreground: 93a1a1
+
+VERBATIM
+foreground: 673ab7
+font-family: Consolas, Monaco, Andale Mono, Monospace, Courier New
+
+FENCEDCODEBLOCK
+foreground: 673ab7
+font-family: Consolas, Monaco, Andale Mono, Monospace, Courier New
+# [VNote] Codeblock sylte from HighlightJS (bold, italic, underlined, strikeout, color)
+# The last occurence of the same attribute takes effect
+# Could specify multiple attribute in one line
+hljs-comment: 6c6c6c
+hljs-keyword: 0000ee
+hljs-attribute: 0000ee
+hljs-selector-tag: 0000ee
+hljs-meta-keyword: 0000ee
+hljs-doctag: 0000ee
+hljs-name: 0000ee
+hljs-type: 880000
+hljs-string: 880000
+hljs-number: 880000
+hljs-selector-id: 880000
+hljs-selector-class: 880000
+hljs-quote: 880000
+hljs-template-tag: 880000
+hljs-deletion: 880000
+hljs-title: bold, 880000
+hljs-section: bold, 880000
+hljs-regexp: bc6060
+hljs-symbol: bc6060
+hljs-variable: bc6060
+hljs-template-variable: bc6060
+hljs-link: bc6060
+hljs-selector-attr: bc6060
+hljs-selector-pseudo: bc6060
+hljs-literal: af00d7
+hljs-built_in: 008700
+hljs-bullet: 008700
+hljs-code: 008700
+hljs-addition: 008700
+hljs-meta: 1f7199
+hljs-meta-string: 4d99bf
+hljs-emphasis: italic
+hljs-strong: bold
+
+BLOCKQUOTE
+foreground: 00af00
+
+NOTE
+foreground: 0087b5
+
+STRIKE
+foreground: b71c1c
+font-style: strikeout
+
+FRONTMATTER
+foreground: 6c6c6c
+
+INLINEEQUATION
+foreground: 00897b
+font-family: Consolas, Monaco, Andale Mono, Monospace, Courier New
+
+DISPLAYFORMULA
+foreground: 00897b
+font-family: Consolas, Monaco, Andale Mono, Monospace, Courier New
+
+MARK
+foreground: 222222
+background: ffff76

--- a/src/resources/themes/v_next/v_next.palette
+++ b/src/resources/themes/v_next/v_next.palette
@@ -1,0 +1,388 @@
+; File path could be absolute path or relative path (related to this file).
+; Use @color_tag to reference a style.
+
+[metadata]
+qss_file=v_next.qss
+mdhl_file=v_next.mdhl
+css_file=v_next.css
+codeblock_css_file=v_next_codeblock.css
+mermaid_css_file=v_next_mermaid.css
+version=22
+
+[phony]
+; Abstract color attributes.
+master_fg=#000
+master_bg=#D0D0D0
+master_light_bg=#FFFFFF
+master_dark_bg=#000
+master_focus_bg=#FFFFFF
+master_hover_bg=#D0D0D0
+master_pressed_bg=#FFFFFF
+
+base_fg=#222222
+base_bg=#FFFFFF
+
+active_fg=#FC6423
+active_bg=#EBEDEF
+
+main_fg=@base_fg
+main_bg=@base_bg
+
+title_fg=@base_fg
+title_bg=@base_bg
+
+disabled_fg=#9E9E9E
+
+content_fg=@base_fg
+content_bg=@base_bg
+
+; border_bg=#DADADA
+border_bg=#F5F7F9
+separator_bg=#F5F7F9
+
+; hover_bg=#D0D0D0
+hover_fg=@base_fg
+hover_bg=@active_bg
+
+; selected_fg=@base_fg
+; selected_bg=#7BBAB9
+selected_fg=@active_fg
+selected_bg=@active_bg
+
+; inactive_fg=@selected_fg
+; inactive_bg=#99CFCA
+
+focus_fg=@base_fg
+focus_bg=#BDBDBD
+
+pressed_fg=@base_fg
+pressed_bg=#B2B2B2
+
+edit_fg=#222222
+edit_bg=#F5F5F5
+edit_focus_bg=@active_bg
+edit_focus_border=@active_fg
+edit_hover_bg=@active_bg
+edit_hover_border=@active_fg
+edit_selection_fg=@edit_fg
+edit_selection_bg=@active_bg
+
+icon_fg=#222222
+icon_disabled_fg=@disabled_fg
+
+danger_fg=#F5F5F5
+danger_bg=#C9302C
+danger_focus_bg=#D9534F
+danger_hover_bg=#DE6764
+danger_pressed_bg=#AC2925
+
+[soft_defined]
+; VAvatar.
+; The foreground color of the avatar when Captain mode is triggered.
+avatar_captain_mode_fg=@active_fg
+; The background color of the avatar when Captain mode is triggered.
+avatar_captain_mode_bg=@active_bg
+
+; Style of the label in Navigation mode.
+navigation_label_fg=@active_fg
+navigation_label_bg=@active_bg
+
+; Style of the bubble of VButtonWithWidget.
+bubble_fg=@base_fg
+bubble_bg=@base_bg
+
+; Icons' foreground.
+danger_icon_fg=@danger_bg
+item_icon_fg=@icon_fg
+title_icon_fg=@icon_fg
+
+; VVimIndicator.
+vim_indicator_key_label_fg=@base_fg
+vim_indicator_mode_label_fg=@base_fg
+vim_indicator_cmd_edit_pending_bg=@selected_bg
+
+; VTabIndicator.
+tab_indicator_label_fg=@base_fg
+tab_indicator_tag_label_fg=#222222
+tab_indicator_tag_label_bg=#ce93db
+
+; Html template.
+template_title_flash_light_fg=@active_fg
+template_title_flash_dark_fg=@active_fg
+
+; Search hit items in list or tree view.
+search_hit_item_fg=@selected_fg
+search_hit_item_bg=#CCE7E4
+
+; Universal Entry CMD Edit border color
+ue_cmd_busy_border=#3F51B5
+ue_cmd_fail_border=@danger_bg
+
+; VListWidget/VTreeWidget separator.
+item_separator_fg=@master_dark_bg
+item_separator_bg=@separator_bg
+
+[widgets]
+; Widget color attributes.
+
+; QWidget.
+widget_fg=@base_fg
+
+; Separator of dock widgets.
+dock_separator_bg=@separator_bg
+dock_separator_hover_bg=@hover_bg
+dock_separator_pressed_bg=@pressed_bg
+
+; Menubar.
+menubar_bg=@main_bg
+menubar_fg=@main_fg
+menubar_item_selected_bg=@selected_bg
+
+; Menu.
+menu_bg=@base_bg
+menu_fg=@base_fg
+menu_border_bg=@border_bg
+menu_item_disabled_fg=@disabled_fg
+menu_item_selected_fg=@base_fg
+menu_item_selected_bg=@selected_bg
+menu_separator_bg=@separator_bg
+menu_icon_fg=@icon_fg
+menu_icon_danger_fg=@danger_icon_fg
+
+; Tooltip.
+tooltip_bg=@base_bg
+tooltip_fg=@base_fg
+
+; Toolbar.
+toolbar_bg=@main_bg
+toolbar_separator_bg=@separator_bg
+toolbutton_hover_bg=@hover_bg
+toolbutton_pressed_bg=@pressed_bg
+toolbutton_checked_bg=@selected_bg
+toolbutton_icon_fg=@icon_fg
+toolbutton_icon_danger_fg=@danger_icon_fg
+
+; Toolbox.
+toolbox_icon_fg=@base_fg
+toolbox_icon_active_fg=@active_fg
+toolbox_title_border=@active_bg
+
+; Dockwidget.
+dockwidget_bg=@base_bg
+dockwidget_title_fg=@title_fg
+dockwidget_title_bg=@title_bg
+dockwidget_button_hover_bg=@hover_bg
+
+; PushButton.
+pushbutton_fg=@base_fg
+pushbutton_bg=@base_bg
+pushbutton_border=@border_bg
+pushbutton_pressed_bg=@pressed_bg
+pushbutton_focus_bg=@base_bg
+pushbutton_checked_bg=@selected_bg
+pushbutton_hover_bg=@hover_bg
+pushbutton_default_border=@active_fg
+pushbutton_disabled_fg=@disabled_fg
+pushbutton_disabled_bg=@pushbutton_bg
+
+pushbutton_specialbtn_fg=@active_fg
+pushbutton_specialbtn_bg=@base_bg
+pushbutton_specialbtn_focus_bg=@base_bg
+pushbutton_specialbtn_hover_bg=@hover_bg
+pushbutton_specialbtn_checked_bg=#3F51B5
+pushbutton_specialbtn_pressed_bg=@master_pressed_bg
+
+pushbutton_titlebtn_bg=@title_bg
+
+pushbutton_dangerbtn_fg=@danger_fg
+pushbutton_dangerbtn_bg=@danger_bg
+pushbutton_dangerbtn_hover_bg=@danger_hover_bg
+pushbutton_dangerbtn_focus_bg=@danger_focus_bg
+pushbutton_dangerbtn_pressed_bg=@danger_pressed_bg
+
+pushbutton_toolboxbtn_active_fg=@active_fg
+pushbutton_toolboxbtn_active_bg=@active_bg
+pushbutton_toolboxbtn_active_focus_bg=@focus_bg
+pushbutton_toolboxbtn_active_hover_bg=@hover_bg
+pushbutton_toolboxbtn_active_pressed_bg=@master_pressed_bg
+
+button_icon_fg=@icon_fg
+button_icon_danger_fg=@danger_icon_fg
+
+buttonmenuitem_decoration_text_fg=@master_dark_bg
+
+; ComboBox.
+combobox_border=@border_bg
+combobox_fg=@content_fg
+combobox_bg=@content_bg
+combobox_disabled_fg=@disabled_fg
+combobox_view_border=@border_bg
+combobox_view_selected_bg=@selected_bg
+combobox_view_selected_fg=@selected_fg
+combobox_view_item_hover_fg=@hover_fg
+combobox_view_item_hover_bg=@hover_bg
+combobox_focus_bg=@edit_focus_bg
+combobox_focus_border=@edit_focus_border
+combobox_hover_bg=@edit_hover_bg
+combobox_hover_border=@edit_hover_border
+combobox_item_icon_fg=@item_icon_fg
+
+combobox_notebookselector_fg=@base_fg
+combobox_notebookselector_bg=@base_bg
+combobox_notebookselector_border=@base_bg
+combobox_notebookselector_hover_fg=@hover_fg
+combobox_notebookselector_hover_bg=@active_bg
+combobox_notebookselector_focus_fg=@active_fg
+combobox_notebookselector_focus_bg=@active_bg
+
+; Label.
+label_fg=@base_fg
+label_titlelabel_fg=@title_fg
+label_titlelabel_bg=@title_bg
+
+; LineEdit.
+lineedit_border=@border_bg
+lineedit_fg=@edit_fg
+lineedit_bg=@edit_bg
+lineedit_disabled_fg=@disabled_fg
+lineedit_focus_bg=@edit_focus_bg
+lineedit_focus_border=@edit_focus_border
+lineedit_hover_bg=@edit_hover_bg
+lineedit_hover_border=@edit_hover_border
+lineedit_selection_fg=@edit_selection_fg
+lineedit_selection_bg=@edit_selection_bg
+
+; TabWidget.
+tabwidget_pane_border=@border_bg
+
+; TabBar.
+tabbar_fg=@base_fg
+tabbar_bg=@base_bg
+tabbar_border=@border_bg
+
+tabbar_selected_fg=@selected_fg
+tabbar_selected_bg=@selected_bg
+tabbar_selected_border=@selected_fg
+
+tabbar_hover_fg=@hover_fg
+tabbar_hover_bg=@hover_bg
+
+tabbar_icon_fg=@icon_fg
+tabbar_icon_special_fg=@danger_bg
+
+; SelectorItem.
+selectoritem_border=@base_fg
+selectoritem_fg=@base_fg
+selectoritem_bg=@base_bg
+
+; InsertSelector.
+insertselector_bg=@base_bg
+
+; TreeView.
+treeview_fg=@content_fg
+treeview_bg=@content_bg
+treeview_item_border_bg=@border_bg
+treeview_item_hover_fg=@hover_fg
+treeview_item_hover_bg=@hover_bg
+treeview_item_selected_fg=@selected_fg
+treeview_item_selected_bg=@selected_bg
+treeview_item_selected_avtive_fg=@active_fg
+treeview_item_selected_avtive_bg=@active_bg
+treeview_item_selected_inactive_fg=@inactive_fg
+treeview_item_selected_inactive_bg=@inactive_bg
+treeview_item_icon_fg=@item_icon_fg
+
+; ListView.
+listview_fg=@content_fg
+listview_bg=@content_bg
+listview_item_hover_fg=@hover_fg
+listview_item_hover_bg=@hover_bg
+listview_item_selected_fg=@selected_fg
+listview_item_selected_bg=@selected_bg
+listview_item_selected_avtive_fg=@active_fg
+listview_item_selected_avtive_bg=@active_bg
+listview_item_selected_inactive_fg=@inactive_fg
+listview_item_selected_inactive_bg=@inactive_bg
+
+; QAbstractItemView for TextEdit Completer.
+abstractitemview_textedit_fg=@content_fg
+abstractitemview_textedit_bg=#DADADA
+abstractitemview_textedit_item_hover_fg=@abstractitemview_textedit_fg
+abstractitemview_textedit_item_hover_bg=@master_hover_bg
+abstractitemview_textedit_item_selected_fg=@abstractitemview_textedit_fg
+abstractitemview_textedit_item_selected_bg=@master_light_bg
+abstractitemview_textedit_item_selected_avtive_fg=@abstractitemview_textedit_fg
+abstractitemview_textedit_item_selected_avtive_bg=@master_focus_bg
+abstractitemview_textedit_item_selected_inactive_fg=@inactive_fg
+abstractitemview_textedit_item_selected_inactive_bg=@inactive_bg
+
+; Splitter.
+splitter_handle_bg=@border_bg
+splitter_handle_pressed_bg=@pressed_bg
+
+; StatusBar.
+statusbar_fg=@border_fg
+statusbar_bg=@border_bg
+
+; ScrollBar.
+scrollbar_bg=@base_bg
+scrollbar_page_bg=transparent
+scrollbar_handle_bg=#DADADA
+scrollbar_handle_hover_bg=@hover_bg
+scrollbar_handle_pressed_bg=@pressed_bg
+
+; VEditWindow.
+editwindow_corner_icon_fg=@base_fg
+editwindow_corner_icon_inactive_fg=#D3D3D3
+
+; CheckBox.
+checkbox_disabled_fg=@disabled_fg
+checkbox_indicator_focus_bg=@focus_bg
+checkbox_indicator_hover_bg=@hover_bg
+checkbox_indicator_pressed_bg=@pressed_bg
+
+; RadioButton.
+radiobutton_disabled_fg=@disabled_fg
+radiobutton_indicator_focus_bg=@focus_bg
+radiobutton_indicator_hover_bg=@hover_bg
+radiobutton_indicator_pressed_bg=@pressed_bg
+
+; SpinBox.
+spinbox_fg=@edit_fg
+spinbox_bg=@edit_bg
+spinbox_border=@border_bg
+spinbox_selection_fg=@edit_selection_fg
+spinbox_selection_bg=@edit_selection_bg
+spinbox_focus_border=@edit_focus_border
+spinbox_focus_bg=@edit_focus_bg
+spinbox_hover_border=@edit_hover_border
+spinbox_hover_bg=@edit_hover_bg
+spinbox_button_hover_bg=@hover_bg
+spinbox_button_pressed_bg=@pressed_bg
+
+; HeaderView.
+headerview_bg=#E0E0E0
+headerview_fg=@base_fg
+headerview_border=@border_bg
+headerview_checked_fg=@selected_fg
+headerview_checked_bg=@selected_bg
+
+; ProgressBar.
+progressbar_bg=@edit_bg
+progressbar_border_bg=@border_bg
+progressbar_chunk_bg=@master_light_bg
+
+universalentry_bg=@base_bg
+universalentry_border_bg=@border_bg
+
+doublerowitem_second_row_label_fg=#6C6C6C
+
+; GroupBox.
+groupbox_border=@border_bg
+groupbox_title_fg=@base_fg
+
+; Slider.
+slider_border_bg=@border_bg
+slider_groove_bg=@edit_bg
+slider_handle_bg=@base_fg
+slider_subpage_bg=@master_light_bg

--- a/src/resources/themes/v_next/v_next.qss
+++ b/src/resources/themes/v_next/v_next.qss
@@ -1,0 +1,1460 @@
+QToolTip
+{
+    border: none;
+    background: @tooltip_bg;
+    color: @tooltip_fg;
+}
+
+/* QMainWindow */
+QMainWindow {
+    color: @base_fg;
+    background: @base_bg;
+}
+
+QMainWindow::separator {
+    background: @dock_separator_bg;
+    width: $2px;
+    height: $2px;
+}
+
+QMainWindow::separator:hover {
+    background: @dock_separator_hover_bg;
+}
+
+QMainWindow::separator:pressed {
+    background: @dock_separator_pressed_bg;
+}
+/* End QMainWindow */
+
+QMenuBar {
+    border: none;
+    background: @menubar_bg;
+    color: @menubar_fg;
+}
+
+QMenuBar::item:selected {
+    background: @menubar_item_selected_bg;
+}
+
+/* QMenu */
+QMenu {
+    background: @menu_bg;
+    color: @menu_fg;
+    border: $2px solid @menu_border_bg;
+}
+
+QMenu::icon {
+    margin: $5px;
+}
+
+QMenu::item {
+    padding: $5px $30px $5px $30px;
+    border: $1px solid transparent;
+}
+
+QMenu::item:selected {
+    color: @menu_item_selected_fg;
+    background: @menu_item_selected_bg;
+}
+
+QMenu::item:disabled {
+    color: @menu_item_disabled_fg;
+}
+
+QMenu::icon:checked { /* appearance of a 'checked' icon */
+    border: $2px solid @menu_fg;
+}
+
+QMenu::separator {
+    height: $2px;
+    background: @menu_separator_bg;
+    margin-left: $10px;
+    margin-right: $5px;
+}
+
+QMenu::indicator {
+    width: $20px;
+    height: $20px;
+}
+
+QMenu::indicator:non-exclusive:unchecked {
+    image: none;
+}
+
+QMenu::indicator:non-exclusive:checked {
+    image: url(menu_checkbox.svg);
+}
+
+QMenu::indicator:exclusive:unchecked {
+    image: none;
+}
+
+QMenu::indicator:exclusive:checked {
+    image: url(menu_radiobutton.svg);
+}
+/* End QMenu */
+
+QToolBar {
+    border: none;
+    background: @toolbar_bg;
+}
+
+QToolBar::separator {
+    width: 1px;
+    height: 1px;
+    border: none;
+    background: @toolbar_separator_bg;
+}
+
+/* QToolButton */
+QToolButton[popupMode="1"] { /* only for MenuButtonPopup */
+    padding-right: $16px; /* make way for the popup button */
+}
+
+QToolButton[popupMode="2"] { /* only for InstantPopup */
+    padding-right: $10px; /* make way for the popup button */
+}
+
+QToolButton {
+    border: none;
+    background: transparent;
+    margin: 1px 3px 1px 3px;
+    padding: 0px;
+}
+
+QToolButton:checked {
+    background: @toolbutton_checked_bg;
+}
+
+QToolButton:hover {
+    border:none;
+    background: @toolbutton_hover_bg;
+}
+
+QToolButton:pressed {
+    background: @toolbutton_pressed_bg;
+}
+
+/* the subcontrols below are used only in the MenuButtonPopup mode */
+QToolButton::menu-button {
+    border: none;
+    width: $16px;
+}
+
+QToolButton::menu-arrow {
+    image: url(arrow_dropdown.svg);
+    width: $16px;
+    height: $16px;
+}
+/* End QToolButton*/
+
+/* DockWidget */
+QDockWidget {
+    color: @dockwidget_title_fg;
+    background: @dockwidget_bg;
+    titlebar-close-icon: url(close.svg);
+    titlebar-normal-icon: url(float.svg);
+}
+
+QDockWidget::Title {
+    background: @dockwidget_title_bg;
+    text-align: center left;
+}
+
+QDockWidget::close-button, QDockWidget::float-button {
+    border: none;
+    icon-size: $16px;
+    width: $16px;
+}
+
+QDockWidget::close-button:hover, QDockWidget::float-button:hover {
+    background: @dockwidget_button_hover_bg;
+}
+
+QDockWidget::close-button {
+    subcontrol-position: top right;
+    subcontrol-origin: margin;
+    position: absolute;
+    top: 0px; right: 0px; bottom: 0px;
+}
+
+QDockWidget::float-button {
+    subcontrol-position: top right;
+    subcontrol-origin: margin;
+    position: absolute;
+    top: 0px; right: $18px; bottom: 0px;
+}
+/* End DockWidget */
+
+/* QPushButton */
+QPushButton[SpecialBtn="true"] {
+    color: @pushbutton_specialbtn_fg;
+    background: @pushbutton_specialbtn_bg;
+}
+
+QPushButton[SpecialBtn="true"]:default {
+    border: 1px solid @pushbutton_default_border;
+    background-color: @pushbutton_specialbtn_bg;
+}
+
+QPushButton[SpecialBtn="true"]:focus {
+    background-color: @pushbutton_specialbtn_focus_bg;
+}
+
+QPushButton[SpecialBtn="true"]:checked {
+    background-color: @pushbutton_specialbtn_checked_bg;
+}
+
+QPushButton[SpecialBtn="true"]:hover {
+    background-color: @pushbutton_specialbtn_hover_bg;
+}
+
+QPushButton[SpecialBtn="true"]:pressed {
+    background-color: @pushbutton_specialbtn_pressed_bg;
+}
+
+QPushButton[CornerBtn="true"] {
+    padding: 4px -2px 4px -2px;
+    margin: 0px;
+    border: none;
+    background-color: transparent;
+    min-width: -1;
+}
+
+QPushButton[CornerBtn="true"]::menu-indicator {
+    image: none;
+}
+
+QPushButton[StatusBtn="true"] {
+    font: bold;
+    padding: 0px 2px 0px 2px;
+    margin: 0px;
+    border: none;
+    background-color: transparent;
+    min-width: -1;
+}
+
+QPushButton[FlatBtn="true"] {
+    padding: 4px;
+    margin: 0px;
+    border: none;
+    background-color: transparent;
+    min-width: -1;
+}
+
+QPushButton[SelectionBtn="true"] {
+    padding: 4px 10px 4px 10px;
+    border: none;
+    background-color: transparent;
+    font-size: 15pt;
+    text-align: left;
+    min-width: -1;
+}
+
+QPushButton[TitleBtn="true"] {
+    padding: 4px;
+    margin: 0px;
+    border: none;
+    background-color: @pushbutton_titlebtn_bg;
+    min-width: -1;
+}
+
+QPushButton[DangerBtn="true"] {
+    color: @pushbutton_dangerbtn_fg;
+    border: none;
+    background-color: @pushbutton_dangerbtn_bg;
+    min-width: -1;
+}
+
+QPushButton[DangerBtn="true"]:default {
+    border: 1px solid @pushbutton_default_border;
+    background-color: @pushbutton_dangerbtn_bg;
+}
+
+QPushButton[DangerBtn="true"]:focus {
+    background-color: @pushbutton_dangerbtn_focus_bg;
+}
+
+QPushButton[DangerBtn="true"]:checked {
+    background-color: @pushbutton_dangerbtn_pressed_bg;
+}
+
+QPushButton[DangerBtn="true"]:hover {
+    background-color: @pushbutton_dangerbtn_hover_bg;
+}
+
+QPushButton[DangerBtn="true"]:pressed {
+    background-color: @pushbutton_dangerbtn_pressed_bg;
+}
+
+QPushButton[ToolBoxActiveBtn="true"] {
+    padding: 4px 10px 4px 4px;
+    margin: 0px;
+    border: none;
+    font-weight: bold;
+    color: @pushbutton_toolboxbtn_active_fg;
+    background-color: @pushbutton_toolboxbtn_active_bg;
+    min-width: -1;
+}
+
+QPushButton[ToolBoxActiveBtn="true"]:default {
+    border: 1px solid @pushbutton_default_border;
+    background-color: @pushbutton_toolboxbtn_active_bg;
+}
+
+QPushButton[ToolBoxActiveBtn="true"]:focus {
+    background-color: @pushbutton_toolboxbtn_active_focus_bg;
+}
+
+QPushButton[ToolBoxActiveBtn="true"]:hover {
+    background-color: @pushbutton_toolboxbtn_active_hover_bg;
+}
+
+QPushButton[ToolBoxActiveBtn="true"]:pressed {
+    background-color: @pushbutton_toolboxbtn_active_pressed_bg;
+}
+
+QPushButton[ToolBoxActiveBtn="true"]:disabled {
+    color: @pushbutton_disabled_fg;
+    background-color: @pushbutton_disabled_bg;
+}
+
+QPushButton[AvatarBtn="true"] {
+    padding: 2px 4px 2px 4px;
+    margin: 0px;
+    border: none;
+    background-color: transparent;
+    min-width: -1;
+}
+
+QPushButton {
+    color: @pushbutton_fg;
+    background: @pushbutton_bg;
+    border: 1px solid @pushbutton_border;
+    padding: 3px;
+    min-width: 80px;
+}
+
+QPushButton:focus {
+    background-color: @pushbutton_focus_bg;
+}
+
+QPushButton:checked {
+    background-color: @pushbutton_checked_bg;
+}
+
+QPushButton:flat {
+    border: none;
+}
+
+QPushButton:default {
+    border: 1px solid @pushbutton_default_border;
+}
+
+QPushButton:hover {
+    background-color: @pushbutton_hover_bg;
+}
+
+QPushButton:pressed {
+    background-color: @pushbutton_pressed_bg;
+}
+
+QPushButton:disabled {
+    color: @pushbutton_disabled_fg;
+    background-color: @pushbutton_disabled_bg;
+}
+
+QPushButton::menu-indicator {
+    image: url(arrow_dropdown.svg);
+    width: 16px;
+    height: 16px;
+}
+
+VButtonMenuItem {
+    padding: 5px;
+    padding-right: 30px;
+    border: 1px solid transparent;
+    background-color: transparent;
+    min-width: -1;
+    text-align: left;
+}
+
+VButtonMenuItem[Heading1="true"] {
+    font-size: 22pt;
+}
+
+VButtonMenuItem[Heading2="true"] {
+    font-size: 20pt;
+}
+
+VButtonMenuItem[Heading3="true"] {
+    font-size: 18pt;
+}
+
+VButtonMenuItem[Heading4="true"] {
+    font-size: 16pt;
+}
+
+VButtonMenuItem[Heading5="true"] {
+    font-size: 14pt;
+}
+
+VButtonMenuItem[Heading6="true"] {
+    font-size: 14pt;
+}
+
+VButtonMenuItem:focus {
+    background-color: @menubar_item_selected_bg;
+}
+
+VButtonMenuItem:hover {
+    background-color: @menubar_item_selected_bg;
+}
+
+VButtonMenuItem:disabled {
+    color: @pushbutton_disabled_fg;
+    background-color: @pushbutton_disabled_bg;
+}
+/* End QPushButton*/
+
+/* QComboBox */
+QComboBox#NotebookSelector {
+    border: none;
+    font-size: 12pt;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    icon-size: $24px;
+    font-weight: bold;
+    color: @combobox_notebookselector_fg;
+    background: @combobox_notebookselector_bg;
+}
+
+QComboBox#NotebookSelector:focus, QComboBox#NotebookSelector:on {
+    color: @combobox_notebookselector_focus_fg;
+    background: @combobox_notebookselector_focus_bg;
+}
+
+QComboBox#NotebookSelector:hover {
+    color: @combobox_notebookselector_hover_fg;
+    background: @combobox_notebookselector_hover_bg;
+}
+
+QComboBox#NotebookSelector QListWidget {
+    border: 1px solid @combobox_view_border;
+    background-color: @combobox_bg;
+    font-size: 12pt;
+    font-weight: normal;
+    icon-size: $24px;
+}
+
+QComboBox#NotebookSelector QListWidget::item {
+    padding-top: $5px;
+    padding-bottom: $5px;
+}
+
+QComboBox#NotebookSelector QListWidget::item:hover {
+    color: @combobox_view_item_hover_fg;
+    background-color: @combobox_view_item_hover_bg;
+}
+
+QComboBox {
+    padding: 3px;
+    color: @combobox_fg;
+    background: @combobox_bg;
+    border: 1px solid @combobox_border;
+}
+
+QComboBox:focus, QComboBox:on {
+    background-color: @combobox_focus_bg;
+    border: 2px solid @combobox_focus_border;
+}
+
+QComboBox:hover {
+    background-color: @combobox_hover_bg;
+    border: 2px solid @combobox_hover_border;
+}
+
+QComboBox:disabled {
+    color: @combobox_disabled_fg;
+}
+
+QComboBox::drop-down {
+    subcontrol-origin: padding;
+    subcontrol-position: top right;
+    width: $20px;
+    border: none;
+    background: transparent;
+}
+
+QComboBox::down-arrow {
+    image: url(arrow_dropdown.svg);
+    width: $20px;
+    height: $20px;
+}
+
+QComboBox::down-arrow:disabled {
+    image: url(arrow_dropdown_disabled.svg);
+    width: $20px;
+    height: $20px;
+}
+
+QComboBox QAbstractItemView {
+    padding: 2px;
+    border: 1px solid @combobox_view_border;
+    background: @combobox_bg;
+    selection-color: @combobox_view_selected_fg;
+    selection-background-color: @combobox_view_selected_bg;
+}
+
+QComboBox QAbstractItemView::item {
+    background: transparent;
+    padding: 3px;
+}
+
+QComboBox QAbstractItemView::item:hover {
+    color: @combobox_view_item_hover_fg;
+    background: @combobox_view_item_hover_bg;
+}
+/* End QComboBox */
+
+/* QLabel */
+QLabel[TitleLabel="true"] {
+    padding-top: 5px;
+    padding-bottom: 5px;
+    color: @label_titlelabel_fg;
+    background-color: @label_titlelabel_bg;
+}
+
+QLabel[ColorRedLabel="true"] {
+    padding-left: 5px;
+    padding-right: 5px;
+    font: bold;
+    color: white;
+    border-radius: 2px;
+    background-color: #D32F2F;
+}
+
+QLabel[ColorGreenLabel="true"] {
+    padding-left: 5px;
+    padding-right: 5px;
+    font: bold;
+    color: white;
+    border-radius: 2px;
+    background-color: #388E3C;
+}
+
+QLabel[ColorGreyLabel="true"] {
+    padding-left: 5px;
+    padding-right: 5px;
+    font: bold;
+    color: white;
+    border-radius: 2px;
+    background-color: #616161;
+}
+
+QLabel[ColorTealLabel="true"] {
+    padding-left: 5px;
+    padding-right: 5px;
+    font: bold;
+    color: white;
+    border-radius: 2px;
+    background-color: #00796B;
+}
+
+QLabel[MenuSeparator="true"] {
+    padding-top: 5px;
+    padding-bottom: 5px;
+    margin-top: 3px;
+    font: italic;
+    border-top: 1px solid @menu_separator_bg
+}
+
+QLabel[TagLabel="true"] {
+    padding-left: $5px;
+    padding-right: $5px;
+    color: @tab_indicator_tag_label_fg;
+    background-color: @tab_indicator_tag_label_bg;
+}
+
+VVimIndicator QLabel[VimIndicatorKeyLabel="true"] {
+    font: bold;
+    color: @vim_indicator_key_label_fg;
+    background: transparent;
+}
+
+VVimIndicator QLabel[VimIndicatorModeLabel="true"] {
+    padding: 0px 2px 0px 2px;
+    font: bold;
+    color: @vim_indicator_mode_label_fg;
+    /* background color will be controlled by the code. */
+}
+
+VTabIndicator QLabel[TabIndicatorLabel="true"] {
+    color: @tab_indicator_label_fg;
+    background: transparent;
+}
+
+VSelectorItemWidget QLabel[SelectorItemShortcutLabel="true"] {
+    font: bold;
+    border: $2px solid @selectoritem_border;
+    padding: 3px;
+    border-radius: 5px;
+    background-color: @selectoritem_bg;
+    color: @selectoritem_fg;
+}
+
+VDoubleRowItemWidget QLabel[FirstRowLabel="true"] {
+    border: none;
+    font-size: 10pt;
+}
+
+VDoubleRowItemWidget QLabel[SecondRowLabel="true"] {
+    border: none;
+    font-size: 9pt;
+    color: @doublerowitem_second_row_label_fg;
+}
+
+QLabel {
+    border: none;
+    color: @label_fg;
+    background: transparent;
+}
+/* End QLabel */
+
+/* QLineEdit */
+QLineEdit[VimCommandLine="true"] {
+    padding: 0px;
+    margin: 0px;
+    border: none;
+    color: @lineedit_fg;
+    background: @lineedit_bg;
+}
+
+QLineEdit[VimCommandLine="true"]:focus {
+    background: @lineedit_focus_bg;
+    border: none;
+}
+
+QLineEdit[VimCommandLine="true"]:hover {
+    background: @lineedit_hover_bg;
+    border: none;
+}
+
+QLineEdit[EmbeddedEdit="true"] {
+    padding: 0px;
+    margin: 0px;
+    border: none;
+    color: @lineedit_fg;
+    background: transparent;
+}
+
+QLineEdit[EmbeddedEdit="true"]:focus {
+    background: @lineedit_focus_bg;
+    border: none;
+}
+
+QLineEdit[EmbeddedEdit="true"]:hover {
+    background: @lineedit_hover_bg;
+    border: none;
+}
+
+QLineEdit {
+    border: 1px solid @lineedit_border;
+    padding: 3px;
+    color: @lineedit_fg;
+    background: @lineedit_bg;
+    selection-color: @lineedit_selection_fg;
+    selection-background-color: @lineedit_selection_bg;
+}
+
+QLineEdit:focus {
+    border: 2px solid @lineedit_focus_border;
+    background: @lineedit_focus_bg;
+}
+
+QLineEdit:hover {
+    border: 2px solid @lineedit_hover_border;
+    background: @lineedit_hover_bg;
+}
+
+QLineEdit:disabled {
+    color: @lineedit_disabled_fg;
+}
+/* End QLineEdit */
+
+/* QPlainTextEdit QTextEdit */
+QPlainTextEdit[LineEdit="true"], QTextEdit[LineEdit="true"] {
+    border: 1px solid @lineedit_border;
+    padding: 3px;
+    color: @lineedit_fg;
+    background: @lineedit_bg;
+    selection-color: @lineedit_selection_fg;
+    selection-background-color: @lineedit_selection_bg;
+}
+
+QPlainTextEdit[LineEdit="true"]:focus, QTextEdit[LineEdit="true"]:focus {
+    border: 2px solid @lineedit_focus_border;
+    background: @lineedit_focus_bg;
+}
+
+QPlainTextEdit[LineEdit="true"]:hover, QTextEdit[LineEdit="true"]:hover {
+    border: 2px solid @lineedit_hover_border;
+    background: @lineedit_hover_bg;
+}
+/* End QPlainTextEdit QTextEdit */
+
+/* QTabWidget */
+QTabWidget {
+    border: none;
+}
+
+QTabWidget::pane {
+    border: none;
+}
+/* End QTabWidget */
+
+/* QTabBar */
+QTabBar::tab {
+    color: @tabbar_fg;
+    background: @tabbar_bg;
+    border: none;
+}
+
+QTabBar::tab:top, QTabBar::tab:bottom {
+    border-top: $2px solid transparent;
+    border-right: $1px solid @tabbar_border;
+    /* MUST leave right and left padding 0px. */
+    padding: $2px 0px $2px 0px;
+    height: $20px;
+}
+
+QTabBar::tab:right {
+    border-left: $3px solid transparent;
+    border-bottom: $1px solid @tabbar_border;
+    padding: $5px $2px $5px $2px;
+    min-width: $20px;
+}
+
+QTabBar::tab:left {
+    border-right: $3px solid transparent;
+    border-bottom: $1px solid @tabbar_border;
+    padding: $5px $2px $5px $2px;
+    min-width: $20px;
+}
+
+QTabBar::tab:hover {
+    color: @tabbar_hover_fg;
+    background: @tabbar_hover_bg;
+}
+
+QTabBar::tab:selected {
+    color: @tabbar_selected_fg;
+    background: @tabbar_selected_bg;
+}
+
+QTabBar::tab:top:selected, QTabBar::tab:bottom:selected {
+    border-top: $2px solid @tabbar_selected_border;
+}
+
+QTabBar::tab:right:selected {
+    border-left: $3px solid @tabbar_selected_border;
+}
+
+QTabBar::tab:left:selected {
+    border-right: $3px solid @tabbar_selected_border;
+}
+
+QTabBar::close-button {
+    image: url(close_grey.svg);
+}
+
+QTabBar::close-button:focus {
+    image: url(close.svg);
+}
+
+QTabBar::close-button:hover {
+    image: url(close.svg);
+}
+
+QTabBar::scroller {
+    width: $20px;
+}
+
+QTabBar QToolButton {
+    border: none;
+}
+
+QTabBar QToolButton::right-arrow:enabled {
+    image: url(right.svg);
+}
+
+QTabBar QToolButton::left-arrow:enabled {
+    image: url(left.svg);
+}
+
+QTabBar QToolButton::right-arrow:disabled {
+    image: url(right_disabled.svg);
+}
+
+QTabBar QToolButton::left-arrow:disabled {
+    image: url(left_disabled.svg);
+}
+/* End QTabBar */
+
+/* QTreeView */
+QTreeView[ItemBorder="true"]::item {
+    padding-top: 5px;
+    padding-bottom: 5px;
+    border-bottom: $1px solid @treeview_item_border_bg;
+}
+
+QTreeView[PlainTree="true"]::branch:has-siblings:!adjoins-item {
+    border-image: none;
+}
+
+QTreeView[PlainTree="true"]::branch:has-siblings:adjoins-item {
+    border-image: none;
+}
+
+QTreeView[PlainTree="true"]::branch:!has-children:!has-siblings:adjoins-item {
+    border-image: none;
+}
+
+QTreeView[PlainTree="true"]::branch:has-children:!has-siblings:closed,
+QTreeView[PlainTree="true"]::branch:closed:has-children:has-siblings {
+    border-image: none;
+    image: none;
+}
+
+QTreeView[PlainTree="true"]::branch:open:has-children:!has-siblings,
+QTreeView[PlainTree="true"]::branch:open:has-children:has-siblings  {
+    border-image: none;
+    image: none;
+}
+
+QTreeView {
+    color: @treeview_fg;
+    background: @treeview_bg;
+    show-decoration-selected: 0;
+    border: none;
+    selection-background-color: transparent;
+    outline: none;
+}
+
+QTreeView::item {
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+
+QTreeView::item:hover {
+    color: @treeview_item_hover_fg;
+    background: @treeview_item_hover_bg;
+}
+
+QTreeView::item:selected {
+    color: @treeview_item_selected_fg;
+    background: @treeview_item_selected_bg;
+}
+
+QTreeView::item:selected:active {
+    color: @treeview_item_selected_active_fg;
+    background: @treeview_item_selected_active_bg;
+}
+
+QTreeView::item:selected:!active {
+    color: @treeview_item_selected_inactive_fg;
+    background: @treeview_item_selected_inactive_bg;
+}
+
+QTreeView::branch:has-siblings:!adjoins-item {
+    border-image: url(line.svg) 0;
+}
+
+QTreeView::branch:has-siblings:adjoins-item {
+    border-image: url(branch_more.svg) 0;
+}
+
+QTreeView::branch:!has-children:!has-siblings:adjoins-item {
+    border-image: url(branch_end.svg) 0;
+}
+
+QTreeView::branch:has-children:!has-siblings:closed,
+QTreeView::branch:closed:has-children:has-siblings {
+    border-image: none;
+    image: url(branch_closed.svg);
+}
+
+QTreeView::branch:open:has-children:!has-siblings,
+QTreeView::branch:open:has-children:has-siblings  {
+    border-image: none;
+    image: url(branch_open.svg);
+}
+/* End QTreeView */
+
+/* QListView */
+QListView {
+    color: @listview_fg;
+    background: @listview_bg;
+    show-decoration-selected: 0;
+    border: none;
+    selection-background-color: transparent;
+    outline: none;
+}
+
+QListView::item {
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+
+QListView::item:hover {
+    color: @listview_item_hover_fg;
+    background: @listview_item_hover_bg;
+}
+
+QListView::item:selected {
+    color: @listview_item_selected_fg;
+    background: @listview_item_selected_bg;
+}
+
+QListView::item:selected:active {
+    color: @listview_item_selected_active_fg;
+    background: @listview_item_selected_active_bg;
+}
+
+QListView::item:selected:!active {
+    color: @listview_item_selected_inactive_fg;
+    background: @listview_item_selected_inactive_bg;
+}
+
+QListView::item:disabled {
+    background: transparent;
+}
+/* End QListView */
+
+/* QAbstractItemView for TextEdit Completer popup*/
+QAbstractItemView[TextEdit="true"] {
+    color: @abstractitemview_textedit_fg;
+    background: @abstractitemview_textedit_bg;
+    show-decoration-selected: 0;
+    border: none;
+    selection-background-color: transparent;
+    outline: none;
+}
+
+QAbstractItemView[TextEdit="true"]::item {
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+
+QAbstractItemView[TextEdit="true"]::item:hover {
+    color: @abstractitemview_textedit_item_hover_fg;
+    background: @abstractitemview_textedit_item_hover_bg;
+}
+
+QAbstractItemView[TextEdit="true"]::item:selected {
+    color: @abstractitemview_textedit_item_selected_fg;
+    background: @abstractitemview_textedit_item_selected_bg;
+}
+
+QAbstractItemView[TextEdit="true"]::item:selected:active {
+    color: @abstractitemview_textedit_item_selected_active_fg;
+    background: @abstractitemview_textedit_item_selected_active_bg;
+}
+
+QAbstractItemView[TextEdit="true"]::item:selected:!active {
+    color: @abstractitemview_textedit_item_selected_inactive_fg;
+    background: @abstractitemview_textedit_item_selected_inactive_bg;
+}
+
+QAbstractItemView[TextEdit="true"]::item:disabled {
+    background: transparent;
+}
+/* End QAbstractItemView */
+
+/* QSplitter */
+QSplitter#MainSplitter {
+    border: none;
+    margin-left: $3px;
+}
+
+QSplitter {
+    border: none;
+}
+
+QSplitter::handle {
+    background-color: @splitter_handle_bg;
+}
+
+QSplitter::handle:pressed {
+    background-color: @splitter_handle_pressed_bg;
+}
+
+QSplitter::handle:vertical {
+    height: $2px;
+}
+
+QSplitter::handle:horizontal {
+    width: $2px;
+}
+/* End QSplitter */
+
+/* QStatusBar */
+QStatusBar {
+    color: @statusbar_fg;
+    background: @statusbar_bg;
+}
+/* End QStatusBar */
+
+QDialog {
+    color: @base_fg;
+    background: @base_bg;
+}
+
+/* QScrollBar */
+QScrollBar::add-page, QScrollBar::sub-page {
+    background: @scrollbar_page_bg;
+}
+
+QScrollBar:vertical {
+    background: @scrollbar_bg;
+    width: $16px;
+    margin: $16px 0px $16px 0px;
+    padding: 0px $2px 0px $2px;
+    border: none;
+}
+
+QScrollBar::handle:vertical {
+    background: @scrollbar_handle_bg;
+    min-height: $16px;
+}
+
+QScrollBar::handle:vertical:hover {
+    background: @scrollbar_handle_hover_bg;
+}
+
+QScrollBar::handle:vertical:pressed {
+    background: @scrollbar_handle_pressed_bg;
+}
+
+QScrollBar::add-line:vertical {
+    border: none;
+    background: @scrollbar_bg;
+    width: $16px;
+    height: $16px;
+    subcontrol-position: bottom;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::add-line:vertical:hover {
+    background: @scrollbar_handle_hover_bg;
+}
+
+QScrollBar::add-line:vertical:pressed {
+    background: @scrollbar_handle_pressed_bg;
+}
+
+QScrollBar::sub-line:vertical {
+    border: none;
+    background: @scrollbar_bg;
+    width: $16px;
+    height: $16px;
+    subcontrol-position: top;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:vertical:hover {
+    background: @scrollbar_handle_hover_bg;
+}
+
+QScrollBar::sub-line:vertical:pressed {
+    background: @scrollbar_handle_pressed_bg;
+}
+
+QScrollBar::down-arrow:vertical {
+    image: url(down.svg);
+    width: $16px;
+    height: $16px;
+}
+
+QScrollBar::up-arrow:vertical {
+    image: url(up.svg);
+    width: $16px;
+    height: $16px;
+}
+
+QScrollBar:horizontal {
+    background: @scrollbar_bg;
+    height: $16px;
+    margin: 0px $16px 0px $16px;
+    padding: $2px 0px $2px 0px;
+    border: none;
+}
+
+QScrollBar::handle:horizontal {
+    background: @scrollbar_handle_bg;
+    min-width: $16px;
+}
+
+QScrollBar::handle:horizontal:hover {
+    background: @scrollbar_handle_hover_bg;
+}
+
+QScrollBar::handle:horizontal:pressed {
+    background: @scrollbar_handle_pressed_bg;
+}
+
+QScrollBar::add-line:horizontal {
+    border: none;
+    background: @scrollbar_bg;
+    width: $16px;
+    height: $16px;
+    subcontrol-position: right;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::add-line:horizontal:hover {
+    background: @scrollbar_handle_hover_bg;
+}
+
+QScrollBar::add-line:horizontal:pressed {
+    background: @scrollbar_handle_pressed_bg;
+}
+
+QScrollBar::sub-line:horizontal {
+    border: none;
+    background: @scrollbar_bg;
+    width: $16px;
+    height: $16px;
+    subcontrol-position: left;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:horizontal:hover {
+    background: @scrollbar_handle_hover_bg;
+}
+
+QScrollBar::sub-line:horizontal:pressed {
+    background: @scrollbar_handle_pressed_bg;
+}
+
+QScrollBar::right-arrow:horizontal {
+    image: url(right.svg);
+    width: $16px;
+    height: $16px;
+}
+
+QScrollBar::left-arrow:horizontal {
+    image: url(left.svg);
+    width: $16px;
+    height: $16px;
+}
+/* End QScrollBar */
+
+/* QCheckBox */
+QCheckBox {
+    spacing: $5px;
+}
+
+QCheckBox:disabled {
+    color: @checkbox_disabled_fg;
+}
+
+QCheckBox::indicator:unchecked {
+    image: url(checkbox_unchecked.svg);
+}
+
+QCheckBox::indicator:unchecked:disabled {
+    image: url(checkbox_unchecked_disabled.svg);
+}
+
+QCheckBox::indicator:checked {
+    image: url(checkbox_checked.svg);
+}
+
+QCheckBox::indicator:checked:disabled {
+    image: url(checkbox_checked_disabled.svg);
+}
+
+QCheckBox::indicator {
+    width: $20px;
+    height: $20px;
+}
+
+QCheckBox::indicator:focus {
+    background: @checkbox_indicator_focus_bg;
+}
+
+QCheckBox::indicator:hover {
+    background: @checkbox_indicator_hover_bg;
+}
+
+QCheckBox::indicator:pressed {
+    background: @checkbox_indicator_pressed_bg;
+}
+/* End QCheckBox */
+
+/* QRadioButton */
+QRadioButton {
+    spacing: $5px;
+}
+
+QRadioButton:disabled {
+    color: @radiobutton_disabled_fg;
+}
+
+QRadioButton::indicator:unchecked {
+    image: url(radiobutton_unchecked.svg);
+}
+
+QRadioButton::indicator:unchecked:disabled {
+    image: url(radiobutton_unchecked_disabled.svg);
+}
+
+QRadioButton::indicator:checked {
+    image: url(radiobutton_checked.svg);
+}
+
+QRadioButton::indicator:checked:disabled {
+    image: url(radiobutton_checked_disabled.svg);
+}
+
+QRadioButton::indicator {
+    width: $20px;
+    height: $20px;
+}
+
+QRadioButton::indicator:focus {
+    background: @radiobutton_indicator_focus_bg;
+}
+
+QRadioButton::indicator:hover {
+    background: @radiobutton_indicator_hover_bg;
+}
+
+QRadioButton::indicator:pressed {
+    background: @radiobutton_indicator_pressed_bg;
+}
+/* End QRadioButton */
+
+/* QSpinBox */
+QSpinBox, QDoubleSpinBox {
+    border: 1px solid @spinbox_border;
+    color: @spinbox_fg;
+    background: @spinbox_bg;
+    padding-right: $25px;
+    min-height: $25px;
+    selection-color: @spinbox_selection_fg;
+    selection-background-color: @spinbox_selection_bg;
+}
+
+QSpinBox:focus, QDoubleSpinBox::focus {
+    border: 2px solid @spinbox_focus_border;
+    background: @spinbox_focus_bg;
+}
+
+QSpinBox:hover, QDoubleSpinBox::hover {
+    border: 2px solid @spinbox_hover_border;
+    background: @spinbox_hover_bg;
+}
+
+QSpinBox::up-button, QDoubleSpinBox::up-button {
+    subcontrol-origin: border;
+    subcontrol-position: top right; /* position at the top right corner */
+    width: $25px;
+    border: none;
+    background: transparent;
+}
+
+QSpinBox::up-button:hover, QDoubleSpinBox::up-button:hover {
+    background: @spinbox_button_hover_bg;
+}
+
+QSpinBox::up-button:pressed, QDoubleSpinBox::up-button:pressed {
+    background: @spinbox_button_pressed_bg;
+}
+
+QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {
+    image: url(up.svg);
+    width: $12px;
+    height: $12px;
+}
+
+QSpinBox::up-arrow:disabled, QSpinBox::up-arrow:off, QDoubleSpinBox::up-arrow:disabled, QDoubleSpinBox::up-arrow:off  {
+    image: url(up_disabled.svg);
+}
+
+QSpinBox::down-button, QDoubleSpinBox::down-button {
+    subcontrol-origin: border;
+    subcontrol-position: bottom right; /* position at the top right corner */
+    width: $25px;
+    border: none;
+    background: transparent;
+}
+
+QSpinBox::down-button:hover, QDoubleSpinBox::down-button:hover {
+    background: @spinbox_button_hover_bg;
+}
+
+QSpinBox::down-button:pressed, QDoubleSpinBox::down-button:pressed {
+    background: @spinbox_button_pressed_bg;
+}
+
+QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
+    image: url(down.svg);
+    width: $12px;
+    height: $12px;
+}
+
+QSpinBox::down-arrow:disabled, QSpinBox::down-arrow:off, QDoubleSpinBox::down-arrow:disabled, QDoubleSpinBox::down-arrow:off {
+    image: url(down_disabled.svg);
+}
+/* End QSpinBox */
+
+/* QHeaderView */
+QHeaderView::section {
+    background: @headerview_bg;
+    color: @headerview_fg;
+    padding-left: 4px;
+    border: none;
+    border-left: 1px solid @headerview_border;
+    border-bottom: 1px solid @headerview_border;
+}
+
+QHeaderView::section:checked
+{
+    color: @headerview_checked_fg;
+    background: @headerview_checked_bg;
+}
+
+/* style the sort indicator */
+QHeaderView::down-arrow {
+    image: url(down.svg);
+    width: $12px;
+    height: $12px;
+}
+
+QHeaderView::up-arrow {
+    image: url(up.svg);
+    width: $12px;
+    height: $12px;
+}
+/* End QHeaderView */
+
+QAbstractScrollArea::corner {
+    background: @scrollbar_bg;
+    border: none;
+}
+
+/* QProgressBar */
+QProgressBar {
+    background: @progressbar_bg;
+    border: $1px solid @progressbar_border_bg;
+    text-align: center;
+}
+
+QProgressBar::chunk {
+    background-color: @progressbar_chunk_bg;
+    width: $20px;
+}
+/* End QProgressBar */
+
+/* QGroupBox */
+QGroupBox {
+    border: 2px solid @groupbox_border;
+    border-radius: 5px;
+    margin-top: 2ex;
+}
+
+QGroupBox::title {
+    color: @groupbox_title_fg;
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    position: absolute;
+    padding: 0 $3px;
+    top: 0px; left: $10px; bottom: 0px;
+}
+/* End QGroupBox */
+
+/* QSlider */
+QSlider::groove:horizontal {
+    border: $1px solid @slider_border_bg;
+    height: $8px;
+    background: @slider_groove_bg;
+    margin: $2px 0;
+}
+
+QSlider::handle:horizontal {
+    border: $1px solid @slider_border_bg;
+    background: @slider_handle_bg;
+    width: $18px;
+    margin: $-2px 0;
+}
+
+QSlider::add-page:horizontal {
+    background: transparent;
+}
+
+QSlider::sub-page:horizontal {
+    border: $1px solid @slider_border_bg;
+    background: @slider_subpage_bg;
+    margin: $2px 0;
+}
+
+QSlider::groove:vertical {
+    border: $1px solid @slider_border_bg;
+    width: $8px;
+    background: @slider_groove_bg;
+    margin: 0 $2px;
+}
+
+QSlider::handle:vertical {
+    border: $1px solid @slider_border_bg;
+    background: @slider_handle_bg;
+    height: $18px;
+    margin: 0 $-2px;
+}
+
+QSlider::add-page:vertical {
+    background: transparent;
+}
+
+QSlider::sub-page:vertical {
+    border: $1px solid @slider_border_bg;
+    background: @slider_subpage_bg;
+    margin: 0 $2px;
+}
+/* End QSlider */
+
+/* QWidget */
+QWidget#FindReplaceTitleWidget {
+    background: @title_bg;
+}
+
+QWidget[ToolBoxTitle="true"] {
+    border-bottom: $2px solid @toolbox_title_border;
+}
+
+QWidget[ToolBoxTitle="true"] QPushButton[ToolBoxTitleBtn="true"] {
+    height: $20px;
+}
+
+QWidget[MainEditor="true"] {
+    border: none;
+}
+
+QWidget
+{
+    color: @widget_fg;
+    font-family: "Hiragino Sans GB", "冬青黑体", "Microsoft YaHei", "微软雅黑", "Microsoft YaHei UI", "WenQuanYi Micro Hei", "文泉驿雅黑", "Dengxian", "等线体", "STXihei", "华文细黑", "Liberation Sans", "Droid Sans", "NSimSun", "新宋体", "SimSun", "宋体", "Helvetica", "sans-serif", "Tahoma", "Arial", "Verdana", "Geneva", "Georgia", "Times New Roman";
+}
+
+VInsertSelector {
+    border: none;
+    background: @insertselector_bg;
+}
+
+VUniversalEntry {
+    background: @universalentry_bg;
+    border: 1px solid @universalentry_border_bg;
+}
+/* End QWidget */

--- a/src/resources/themes/v_next/v_next_codeblock.css
+++ b/src/resources/themes/v_next/v_next_codeblock.css
@@ -1,0 +1,67 @@
+/**
+ * highlight.js tomorrow style
+ */
+
+.hljs-comment,
+.hljs-quote {
+    color: #8e908c
+}
+
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-regexp,
+.hljs-deletion {
+    color: #c82829
+}
+
+.hljs-number,
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-literal,
+.hljs-type,
+.hljs-params,
+.hljs-meta,
+.hljs-link {
+    color: #f5871f
+}
+
+.hljs-attribute {
+    color: #eab700
+}
+
+.hljs-string,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-addition {
+    color: #718c00
+}
+
+.hljs-title,
+.hljs-section {
+    color: #4271ae
+}
+
+.hljs-keyword,
+.hljs-selector-tag {
+    color: #8959a8
+}
+
+.hljs {
+    display: block;
+    overflow-x: auto;
+    background: #F7F7F7;
+    color: #4d4d4c;
+    padding: 0.5em
+}
+
+.hljs-emphasis {
+    font-style: italic
+}
+
+.hljs-strong {
+    font-weight: bold
+}

--- a/src/resources/themes/v_next/v_next_mermaid.css
+++ b/src/resources/themes/v_next/v_next_mermaid.css
@@ -1,0 +1,320 @@
+/* Flowchart variables */
+/* Sequence Diagram variables */
+/* Gantt chart variables */
+.mermaid-diagram .mermaid .label {
+  color: #333;
+}
+
+.mermaid-diagram .node rect,
+.mermaid-diagram .node circle,
+.mermaid-diagram .node ellipse,
+.mermaid-diagram .node polygon {
+  fill: #ECECFF;
+  stroke: #CCCCFF;
+  stroke-width: 1px;
+}
+
+.mermaid-diagram .edgePath .path {
+  stroke: #333333;
+}
+
+.mermaid-diagram .edgeLabel {
+  background-color: #e8e8e8;
+}
+
+.mermaid-diagram .cluster rect {
+  fill: #ffffde !important;
+  rx: 4 !important;
+  stroke: #aaaa33 !important;
+  stroke-width: 1px !important;
+}
+
+.mermaid-diagram .cluster text {
+  fill: #333;
+}
+
+.mermaid-diagram .actor {
+  stroke: #CCCCFF;
+  fill: #ECECFF;
+}
+
+.mermaid-diagram text.actor {
+  fill: black;
+  stroke: none;
+}
+
+.mermaid-diagram .actor-line {
+  stroke: grey;
+}
+
+.mermaid-diagram .messageLine0 {
+  stroke-width: 1.5;
+  stroke-dasharray: "2 2";
+  marker-end: "url(#arrowhead)";
+  stroke: #333;
+}
+
+.mermaid-diagram .messageLine1 {
+  stroke-width: 1.5;
+  stroke-dasharray: "2 2";
+  stroke: #333;
+}
+
+.mermaid-diagram #arrowhead {
+  fill: #333;
+}
+
+.mermaid-diagram #crosshead path {
+  fill: #333 !important;
+  stroke: #333 !important;
+}
+
+.mermaid-diagram .messageText {
+  fill: #333;
+  stroke: none;
+}
+
+.mermaid-diagram .labelBox {
+  stroke: #CCCCFF;
+  fill: #ECECFF;
+}
+
+.mermaid-diagram .labelText {
+  fill: black;
+  stroke: none;
+}
+
+.mermaid-diagram .loopText {
+  fill: black;
+  stroke: none;
+}
+
+.mermaid-diagram .loopLine {
+  stroke-width: 2;
+  stroke-dasharray: "2 2";
+  marker-end: "url(#arrowhead)";
+  stroke: #CCCCFF;
+}
+
+.mermaid-diagram .note {
+  stroke: #aaaa33;
+  fill: #fff5ad;
+}
+
+.mermaid-diagram .noteText {
+  fill: black;
+  stroke: none;
+  font-family: 'trebuchet ms', verdana, arial;
+  font-size: 14px;
+}
+
+/** Section styling */
+.mermaid-diagram .section {
+  stroke: none;
+  opacity: 0.2;
+}
+
+.mermaid-diagram .section0 {
+  fill: rgba(102, 102, 255, 0.49);
+}
+
+.mermaid-diagram .section2 {
+  fill: #fff400;
+}
+
+.mermaid-diagram .section1,
+.mermaid-diagram .section3 {
+  fill: white;
+  opacity: 0.2;
+}
+
+.mermaid-diagram .sectionTitle0 {
+  fill: #333;
+}
+
+.mermaid-diagram .sectionTitle1 {
+  fill: #333;
+}
+
+.mermaid-diagram .sectionTitle2 {
+  fill: #333;
+}
+
+.mermaid-diagram .sectionTitle3 {
+  fill: #333;
+}
+
+.mermaid-diagram .sectionTitle {
+  text-anchor: start;
+  font-size: 11px;
+  text-height: 14px;
+}
+
+/* Grid and axis */
+.mermaid-diagram .grid .tick {
+  stroke: lightgrey;
+  opacity: 0.3;
+  shape-rendering: crispEdges;
+}
+
+.mermaid-diagram .grid path {
+  stroke-width: 0;
+}
+
+/* Today line */
+.mermaid-diagram .today {
+  fill: none;
+  stroke: red;
+  stroke-width: 2px;
+}
+
+/* Task styling */
+/* Default task */
+.mermaid-diagram .task {
+  stroke-width: 2;
+}
+
+.mermaid-diagram .taskText {
+  text-anchor: middle;
+  font-size: 11px;
+}
+
+.mermaid-diagram .taskTextOutsideRight {
+  fill: black;
+  text-anchor: start;
+  font-size: 11px;
+}
+
+.mermaid-diagram .taskTextOutsideLeft {
+  fill: black;
+  text-anchor: end;
+  font-size: 11px;
+}
+
+/* Specific task settings for the sections*/
+.mermaid-diagram .taskText0,
+.mermaid-diagram .taskText1,
+.mermaid-diagram .taskText2,
+.mermaid-diagram .taskText3 {
+  fill: white;
+}
+
+.mermaid-diagram .task0,
+.mermaid-diagram .task1,
+.mermaid-diagram .task2,
+.mermaid-diagram .task3 {
+  fill: #8a90dd;
+  stroke: #534fbc;
+}
+
+.mermaid-diagram .taskTextOutside0,
+.mermaid-diagram .taskTextOutside2 {
+  fill: black;
+}
+
+.mermaid-diagram .taskTextOutside1,
+.mermaid-diagram .taskTextOutside3 {
+  fill: black;
+}
+
+/* Active task */
+.mermaid-diagram .active0,
+.mermaid-diagram .active1,
+.mermaid-diagram .active2,
+.mermaid-diagram .active3 {
+  fill: #bfc7ff;
+  stroke: #534fbc;
+}
+
+.mermaid-diagram .activeText0,
+.mermaid-diagram .activeText1,
+.mermaid-diagram .activeText2,
+.mermaid-diagram .activeText3 {
+  fill: black !important;
+}
+
+/* Completed task */
+.mermaid-diagram .done0,
+.mermaid-diagram .done1,
+.mermaid-diagram .done2,
+.mermaid-diagram .done3 {
+  stroke: grey;
+  fill: lightgrey;
+  stroke-width: 2;
+}
+
+.mermaid-diagram .doneText0,
+.mermaid-diagram .doneText1,
+.mermaid-diagram .doneText2,
+.mermaid-diagram .doneText3 {
+  fill: black !important;
+}
+
+/* Tasks on the critical line */
+.mermaid-diagram .crit0,
+.mermaid-diagram .crit1,
+.mermaid-diagram .crit2,
+.mermaid-diagram .crit3 {
+  stroke: #ff8888;
+  fill: red;
+  stroke-width: 2;
+}
+
+.mermaid-diagram .activeCrit0,
+.mermaid-diagram .activeCrit1,
+.mermaid-diagram .activeCrit2,
+.mermaid-diagram .activeCrit3 {
+  stroke: #ff8888;
+  fill: #bfc7ff;
+  stroke-width: 2;
+}
+
+.mermaid-diagram .doneCrit0,
+.mermaid-diagram .doneCrit1,
+.mermaid-diagram .doneCrit2,
+.mermaid-diagram .doneCrit3 {
+  stroke: #ff8888;
+  fill: lightgrey;
+  stroke-width: 2;
+  cursor: pointer;
+  shape-rendering: crispEdges;
+}
+
+.mermaid-diagram .doneCritText0,
+.mermaid-diagram .doneCritText1,
+.mermaid-diagram .doneCritText2,
+.mermaid-diagram .doneCritText3 {
+  fill: black !important;
+}
+
+.mermaid-diagram .activeCritText0,
+.mermaid-diagram .activeCritText1,
+.mermaid-diagram .activeCritText2,
+.mermaid-diagram .activeCritText3 {
+  fill: black !important;
+}
+
+.mermaid-diagram .titleText {
+  text-anchor: middle;
+  font-size: 18px;
+  fill: black;
+}
+
+.mermaid-diagram .node text {
+  font-family: 'trebuchet ms', verdana, arial;
+  font-size: 14px;
+}
+
+.mermaid-diagram div.mermaidTooltip {
+  position: absolute;
+  text-align: center;
+  max-width: 200px;
+  padding: 2px;
+  font-family: 'trebuchet ms', verdana, arial;
+  font-size: 12px;
+  background: #ffffde;
+  border: 1px solid #aaaa33;
+  border-radius: 2px;
+  pointer-events: none;
+  z-index: 100;
+}


### PR DESCRIPTION
在 `v_simple` 主题的基础上创作了一款 `v_next` 主题，主打清新素雅风格。

样式主要参照了 [Hexo-NexT 主题](https://github.com/theme-next/hexo-theme-next) ，以及简书的部分设计。

效果如下：

![2019-09-21_173954](https://user-images.githubusercontent.com/19285447/65374329-74517000-dcbb-11e9-92f6-fbd5fdd2af16.jpg)

:point_up: 背景颜色、字体、代码块等参考了 Hexo-NexT（代码块高亮采用 highlight.js 的 tomorrow 样式），行内代码样式参考了简书。

![2019-09-21_174943](https://user-images.githubusercontent.com/19285447/65374322-508e2a00-dcbb-11e9-84b1-2b263c15ecae.jpg)

:point_up: 为配合整体清新素雅的风格，引用块的样式做了特别设计。