### PR TITLE
add QTQUICK_COMPILER_SKIPPED_RESOURCES

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -316,6 +316,8 @@ HEADERS  += vmainwindow.h \
 RESOURCES += \
     vnote.qrc \
     translations.qrc
+    
+QTQUICK_COMPILER_SKIPPED_RESOURCES += vnote.qrc
 
 macx {
     LIBS += -L/usr/local/lib


### PR DESCRIPTION
Reference: [JavaScript Files in Qt Resource Files](https://doc.qt.io/qt-5/qtwebengine-deploying.html#javascript-files-in-qt-resource-files)
