### PR TITLE
fix build with cmake 4

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,14 +31,6 @@ set_source_files_properties(${VX_APP_ICON_MACOS} PROPERTIES
 # Translations
 set(VX_TS_FILES data/core/translations/vnote_zh_CN.ts
     data/core/translations/vnote_ja.ts)
-if((QT_DEFAULT_MAJOR_VERSION EQUAL 6))
-    if((Qt6Widgets_VERSION VERSION_GREATER_EQUAL 6.7.0))
-        qt_add_lupdate(TS_FILES ${VX_TS_FILES}
-            SOURCE_TARGETS vnote)
-    else()
-        qt_add_lupdate(vnote TS_FILES ${VX_TS_FILES})
-    endif()
-endif()
 # Generate .qm files from .ts files (lrelease)
 set_source_files_properties(${VX_TS_FILES} PROPERTIES
     OUTPUT_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/translations")
@@ -67,6 +59,16 @@ add_executable(vnote WIN32 MACOSX_BUNDLE
     main.cpp
     ${VX_APP_ICON_RC_WIN} ${VX_APP_ICON_MACOS} ${VX_RESOURCE_FILES}
 )
+
+# Translations
+if((QT_DEFAULT_MAJOR_VERSION EQUAL 6))
+    if((Qt6Widgets_VERSION VERSION_GREATER_EQUAL 6.7.0))
+        qt_add_lupdate(TS_FILES ${VX_TS_FILES}
+            SOURCE_TARGETS vnote)
+    else()
+        qt_add_lupdate(vnote TS_FILES ${VX_TS_FILES})
+    endif()
+endif()
 
 add_dependencies(vnote VX_EXTRA_RESOURCE)
 


### PR DESCRIPTION
CMake 4 currently throws an error because the target is defined too late.
Moving the qt_add_lupdate invocation behind the target definition resolves this issue.
This currently blocks updating the vnote package on NixOS.

Logs:
> CMake Error at /nix/store/6imjccyx1961dbywrp4jq3m2lhqbmwq5-qtbase-6.10.0/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:1146 (get_property):
>   get_property could not find TARGET vnote.  Perhaps it has not yet been
>   created.
> Call Stack (most recent call first):
>   /nix/store/xnwyg3bn72875lsascmblixl95lcvkpz-qttools-6.10.0/lib/cmake/Qt6LinguistTools/Qt6LinguistToolsMacros.cmake:321 (_qt_internal_get_target_autogen_build_dir)
>   /nix/store/xnwyg3bn72875lsascmblixl95lcvkpz-qttools-6.10.0/lib/cmake/Qt6LinguistTools/Qt6LinguistToolsMacros.cmake:976 (qt6_add_lupdate)
>   src/CMakeLists.txt:36 (qt_add_lupdate)
>
> 
> -- Could NOT find Python (missing: Python_EXECUTABLE Interpreter)
> -- LinuxDeployExecutable: LINUXDEPLOY_EXECUTABLE-NOTFOUND
> -- Configuring incomplete, errors occurred!