### PR TITLE
feat(macos): capture selected text as a note via a system Service

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -74,7 +74,15 @@ jobs:
         with:
           version: 6.9.3
           target: desktop
-          modules: 'qtwebengine qtwebchannel qtpositioning qtpdf qtimageformats qt5compat qtserialport qtdeclarative'
+          # NOTE: do NOT add qtdeclarative here. It is not an aqt add-on module
+          # for Qt 6 -- it ships inside the base desktop package -- and naming
+          # it makes aqt fail this whole step with "The packages
+          # ['qtdeclarative'] were not found while parsing XML of package
+          # information!", before anything is even configured. Qt6::Qml is
+          # available regardless (qtwebengine depends on it); the
+          # test_pdfviewercore_js registration check below is the gate that
+          # proves it.
+          modules: 'qtwebengine qtwebchannel qtpositioning qtpdf qtimageformats qt5compat qtserialport'
           tools: 'tools_opensslv3_src'
           cache: 'true'
 

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -96,7 +96,13 @@ jobs:
         with:
           version: ${{matrix.config.qt}}
           target: desktop
-          modules: 'qtwebengine qtwebchannel qtpositioning qtpdf qtimageformats qt5compat qtserialport qtdeclarative'
+          # NOTE: do NOT add qtdeclarative here. It is not an aqt add-on module
+          # for Qt 6 -- it ships inside the base desktop package -- and naming
+          # it makes aqt fail this whole step with "The packages
+          # ['qtdeclarative'] were not found while parsing XML of package
+          # information!", before anything is even configured. Qt6::Qml is
+          # available regardless (qtwebengine depends on it).
+          modules: 'qtwebengine qtwebchannel qtpositioning qtpdf qtimageformats qt5compat qtserialport'
           cache: 'true'
 
       - name: Create Build Dir

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -28,12 +28,19 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          # NOTE: do NOT add qtdeclarative to qt_modules. It is not an aqt
+          # add-on module for Qt 6 -- it ships inside the base desktop package
+          # -- and naming it makes aqt fail the whole install step with
+          # "The packages ['qtdeclarative'] were not found while parsing XML of
+          # package information!", before anything is even configured. Qt6::Qml
+          # is available regardless (qtwebengine depends on it); the
+          # "Verify test registration" step below is the gate that proves it.
           - name: "Build on Win64 Qt 6"
             arch: win64_msvc2022_64
             vs_version: 2022
             vs_cmd: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"
             qt: 6.9.3
-            qt_modules: "qtwebengine qtwebchannel qtpositioning qtpdf qtimageformats qt5compat qtdeclarative"
+            qt_modules: "qtwebengine qtwebchannel qtpositioning qtpdf qtimageformats qt5compat"
             qt_tools: tools_opensslv3_x64
             qt_major: 6
             suffix: ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,13 @@ set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type, defaults to Release")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# The macOS NSServices provider lives inside src/application.cpp, which is
+# compiled as Objective-C++ on Apple only (see src/CMakeLists.txt). Enabling the
+# language here keeps every other platform on a plain C/CXX project.
+if(APPLE)
+    enable_language(OBJCXX)
+endif()
+
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,17 @@ endif()
 
 add_dependencies(vnote VX_EXTRA_RESOURCE)
 
+if(APPLE)
+    # application.cpp hosts the native NSServices provider ("Create Note in
+    # VNote"), so it must be compiled as Objective-C++. All AppKit code inside
+    # it is guarded by Q_OS_MACOS, so other platforms keep plain C++.
+    set_source_files_properties(application.cpp PROPERTIES LANGUAGE OBJCXX)
+
+    # Resolve AppKit explicitly instead of relying on Qt's private/transitive
+    # framework dependencies.
+    find_library(VX_APPKIT_LIBRARY AppKit REQUIRED)
+endif()
+
 set(VX_LIBS_FOLDER ../libs)
 target_include_directories(vnote PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -126,6 +137,10 @@ if((QT_DEFAULT_MAJOR_VERSION GREATER 5))
     )
 endif()
 
+if(APPLE)
+    target_link_libraries(vnote PRIVATE ${VX_APPKIT_LIBRARY})
+endif()
+
 # Copy the qt.conf on Windows
 if(WIN32)
     add_custom_command(TARGET vnote POST_BUILD
@@ -154,10 +169,14 @@ elseif(APPLE)
     # TODO: declare install for macOS if necessary. For packing, we will manually copy files into
     # the src/vnote.app bundle.
 
-    # The generated Info.plist will be overridden.
+    # The checked-in Info.plist IS the bundle plist: it carries the NSServices
+    # declaration ("Create Note in VNote"), so an ordinary app-target build must
+    # already advertise the Service. Deploy no longer copies it separately, so
+    # build and package cannot diverge.
     set_target_properties(vnote
         PROPERTIES
         OUTPUT_NAME "${PROJECT_NAME}"
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_LIST_DIR}/data/core/Info.plist"
         MACOSX_BUNDLE_BUNDLE_NAME "${PROJECT_NAME}"
         MACOSX_BUNDLE_INFO_STRING "${PROJECT_DESCRIPTION}"
         MACOSX_BUNDLE_GUI_IDENTIFIER "fun.vnote.vnote"

--- a/src/Packaging.cmake
+++ b/src/Packaging.cmake
@@ -168,11 +168,12 @@ if(WIN32)
 
     windeployqt(vnote)
 elseif(APPLE)
-    # Manually copy resources.
+    # Manually copy resources. The bundle Info.plist is NOT copied here: it is
+    # wired into the target through MACOSX_BUNDLE_INFO_PLIST (see
+    # src/CMakeLists.txt), so the built bundle and the packaged bundle always
+    # carry the same plist (including the NSServices declaration).
     set(VX_BUNDLE_CONTENTS_DIR $<TARGET_FILE_DIR:vnote>/..)
     add_custom_target(deploy
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${CMAKE_CURRENT_LIST_DIR}/data/core/Info.plist" ${VX_BUNDLE_CONTENTS_DIR}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${VX_EXTRA_RESOURCE_FILES_RCC} ${VX_BUNDLE_CONTENTS_DIR}/Resources
         COMMAND ${CMAKE_COMMAND} -E make_directory ${VX_BUNDLE_CONTENTS_DIR}/Resources/translations

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -9,13 +9,98 @@
 
 #include <gui/services/themeservice.h>
 
+#ifdef Q_OS_MACOS
+#import <AppKit/AppKit.h>
+#endif
+
 using namespace vnotex;
+
+#ifdef Q_OS_MACOS
+// Native provider for the "Create Note in VNote" system Service declared under
+// NSServices in the bundle Info.plist. It performs NO validation of its own:
+// everything but the AppKit pasteboard extraction goes through
+// Application::dispatchCaptureText, so the native path cannot drift from the
+// tested contract.
+@interface VNoteServiceProvider : NSObject
+@property(nonatomic, assign) vnotex::Application *app;
+- (void)createNoteFromSelection:(NSPasteboard *)p_pboard
+                       userData:(NSString *)p_userData
+                          error:(NSString **)p_error;
+@end
+
+@implementation VNoteServiceProvider
+
+- (void)createNoteFromSelection:(NSPasteboard *)p_pboard
+                       userData:(NSString *)p_userData
+                          error:(NSString **)p_error {
+  Q_UNUSED(p_userData);
+
+  // The Service declares NSSendTypes public.utf8-plain-text; read the matching
+  // modern pasteboard type.
+  NSString *selection = [p_pboard stringForType:NSPasteboardTypeString];
+
+  // A null QString for a missing selection: dispatchCaptureText rejects it.
+  QString text;
+  if (selection) {
+    text = QString::fromNSString(selection);
+  }
+
+  vnotex::Application *app = self.app;
+  QString errorMessage;
+  const bool accepted =
+      vnotex::Application::dispatchCaptureText(text, errorMessage, [app](const QString &p_text) {
+        // Qt window activation alone does not reliably foreground an app that
+        // was invoked from another process.
+        [NSApp activateIgnoringOtherApps:YES];
+        emit app->captureNoteRequested(p_text);
+      });
+
+  if (!accepted && p_error) {
+    *p_error = errorMessage.toNSString();
+  }
+}
+
+@end
+#endif // Q_OS_MACOS
 
 Application::Application(int &p_argc, char **p_argv) : QApplication(p_argc, p_argv) {}
 
-void Application::setThemeService(ThemeService *p_themeService) {
-  m_themeService = p_themeService;
+Application::~Application() {
+#ifdef Q_OS_MACOS
+  if (m_serviceProvider) {
+    [NSApp setServicesProvider:nil];
+    VNoteServiceProvider *provider = static_cast<VNoteServiceProvider *>(m_serviceProvider);
+    m_serviceProvider = nullptr;
+#if !__has_feature(objc_arc)
+    [provider release];
+#else
+    (void)provider;
+#endif
+  }
+#endif
 }
+
+void Application::registerServiceProvider() {
+#ifdef Q_OS_MACOS
+  if (m_serviceProvider) {
+    return;
+  }
+
+  VNoteServiceProvider *provider = [[VNoteServiceProvider alloc] init];
+  provider.app = this;
+
+  // Apple documents that requests may be delivered as soon as the provider is
+  // registered, so callers must have connected captureNoteRequested first.
+  [NSApp setServicesProvider:provider];
+  NSUpdateDynamicServices();
+
+  // Manual retain/release: the project does not compile with ARC. The provider
+  // stays alive for the whole Application lifetime.
+  m_serviceProvider = static_cast<void *>(provider);
+#endif
+}
+
+void Application::setThemeService(ThemeService *p_themeService) { m_themeService = p_themeService; }
 
 void Application::watchThemeFolder(const QString &p_themeFolderPath) {
   if (p_themeFolderPath.isEmpty()) {

--- a/src/application.h
+++ b/src/application.h
@@ -1,6 +1,10 @@
 #ifndef APPLICATION_H
 #define APPLICATION_H
 #include <QApplication>
+#include <QCoreApplication>
+#include <QString>
+
+#include <functional>
 
 class QFileSystemWatcher;
 class QTimer;
@@ -14,6 +18,8 @@ class Application : public QApplication {
 public:
   Application(int &p_argc, char **p_argv);
 
+  ~Application() override;
+
   // Set ThemeService for hot-reload support.
   void setThemeService(ThemeService *p_themeService);
 
@@ -23,8 +29,47 @@ public:
   // Reload the theme resources (stylesheet, icons, etc)
   void reloadThemeResources();
 
+  // Register the native macOS Services provider ("Create Note in VNote").
+  // No-op on other platforms. MUST be called only after captureNoteRequested
+  // has a connected receiver: Apple may dispatch a request to the provider
+  // immediately after registration.
+  void registerServiceProvider();
+
+  // Platform-independent validation/dispatch seam shared with the native macOS
+  // Service provider, which supplies the already-converted (possibly null)
+  // selection text.
+  //
+  // Missing/null or whitespace-only input returns false, writes a non-empty
+  // @p_error and never invokes @p_callback. Accepted input clears @p_error,
+  // invokes @p_callback exactly once with the ORIGINAL unmodified text (never
+  // trimmed) and returns true. An absent callback is a programming error and is
+  // reported as a failure rather than a silent success, so a true return always
+  // means the request was actually dispatched.
+  static bool dispatchCaptureText(const QString &p_text, QString &p_error,
+                                  const std::function<void(const QString &)> &p_callback) {
+    if (p_text.isNull() || p_text.trimmed().isEmpty()) {
+      p_error = QCoreApplication::translate("vnotex::Application",
+                                            "Select some text to create a note in VNote.");
+      return false;
+    }
+
+    if (!p_callback) {
+      p_error = QCoreApplication::translate("vnotex::Application",
+                                            "VNote is not ready to capture a note yet.");
+      return false;
+    }
+
+    p_error.clear();
+    p_callback(p_text);
+    return true;
+  }
+
 signals:
   void openFileRequested(const QString &p_filePath);
+
+  // Emitted when the macOS "Create Note in VNote" Service is invoked on a
+  // non-empty text selection. The text is delivered verbatim.
+  void captureNoteRequested(const QString &p_text);
 
 protected:
   bool event(QEvent *p_event) Q_DECL_OVERRIDE;
@@ -33,6 +78,10 @@ private:
   ThemeService *m_themeService = nullptr;
   QFileSystemWatcher *m_styleWatcher = nullptr;
   QTimer *m_reloadTimer = nullptr;
+
+  // Retained Objective-C service-provider instance (macOS only). Held as void*
+  // so the header stays free of AppKit types.
+  void *m_serviceProvider = nullptr;
 };
 } // namespace vnotex
 

--- a/src/controllers/newnotecontroller.cpp
+++ b/src/controllers/newnotecontroller.cpp
@@ -1,9 +1,9 @@
 #include "newnotecontroller.h"
 
-#include <QFileInfo>
-#include <QDir>
-#include <QJsonObject>
 #include <QDebug>
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonObject>
 
 #include <core/servicelocator.h>
 #include <core/services/notebookcoreservice.h>
@@ -106,15 +106,31 @@ NewNoteResult NewNoteController::createNote(const NewNoteInput &p_input) {
     return result;
   }
 
-  // Write template content if provided.
-  if (!p_input.templateContent.isEmpty()) {
-    EvaluatedTemplate evaluated = evaluateTemplateContent(p_input.templateContent, p_input.name);
-
-    // Get the full path and write content.
+  // Resolve the absolute path of the freshly created file.
+  auto resolveFullPath = [&]() {
     QJsonObject notebookConfig = notebookService->getNotebookConfig(p_input.notebookId);
     QString rootPath = notebookConfig.value(QLatin1String(vxcore::kJsonKeyRootFolder)).toString();
-    QString fullPath = PathUtils::concatenateFilePath(rootPath, filePath);
-    Error err = FileUtils2::writeFile(fullPath, evaluated.content.toUtf8());
+    return PathUtils::concatenateFilePath(rootPath, filePath);
+  };
+
+  if (p_input.bodyMode == NewNoteBodyMode::LiteralContent) {
+    // Captured text: written exactly as given, with no snippet/template
+    // expansion. Written unconditionally so a cleared field yields an empty
+    // note with an offset of zero.
+    Error err = FileUtils2::writeFile(resolveFullPath(), p_input.literalContent.toUtf8());
+    if (err) {
+      qWarning() << err.what();
+      result.success = false;
+      result.errorMessage = tr("Failed to write note content.");
+      return result;
+    }
+    // Qt caret offsets are UTF-16 positions, which is exactly QString::size().
+    result.cursorOffset = p_input.literalContent.size();
+  } else if (!p_input.templateContent.isEmpty()) {
+    // Write template content if provided.
+    EvaluatedTemplate evaluated = evaluateTemplateContent(p_input.templateContent, p_input.name);
+
+    Error err = FileUtils2::writeFile(resolveFullPath(), evaluated.content.toUtf8());
     if (err) {
       qWarning() << err.what();
       result.success = false;
@@ -165,8 +181,7 @@ NewNoteResult NewNoteController::createQuickNote(const QuickNoteInput &p_input) 
 
   QJsonObject notebookConfig = notebookService->getNotebookConfig(p_input.notebookId);
   QString rootFolder = notebookConfig.value(QLatin1String(vxcore::kJsonKeyRootFolder)).toString();
-  QString parentAbsPath =
-      folderPath.isEmpty() ? rootFolder : QDir(rootFolder).filePath(folderPath);
+  QString parentAbsPath = folderPath.isEmpty() ? rootFolder : QDir(rootFolder).filePath(folderPath);
 
   QString newFileName = FileUtils2::generateFileNameWithSequence(
       parentAbsPath, finfo.completeBaseName(), finfo.suffix());
@@ -200,7 +215,7 @@ NewNoteResult NewNoteController::createQuickNote(const QuickNoteInput &p_input) 
 }
 
 EvaluatedTemplate NewNoteController::evaluateTemplateContent(const QString &p_content,
-                                                            const QString &p_name) {
+                                                             const QString &p_name) {
   // Provide magic-symbol overrides (%note%, %no%) derived from the note name,
   // mirroring the legacy SnippetMgr::generateOverrides(fileName). expandContent
   // additionally processes a top-level "@@" cursor mark and "$$" selection mark.

--- a/src/controllers/newnotecontroller.h
+++ b/src/controllers/newnotecontroller.h
@@ -10,13 +10,26 @@ namespace vnotex {
 
 class ServiceLocator;
 
+// Where a new note's body comes from.
+enum class NewNoteBodyMode {
+  // Expand templateContent through the snippet engine (cursor/selection marks,
+  // %note%/%no% overrides).
+  Template,
+  // Write literalContent verbatim: no snippet or template interpretation, so
+  // "%note%", "@@", "$$", tabs and surrounding whitespace all stay literal.
+  LiteralContent
+};
+
 // Input data structure for creating a new note.
 struct NewNoteInput {
   QString notebookId;
   QString parentFolderPath; // Relative path within notebook
   QString name;             // File name with extension
-  QString templateContent;  // Optional template content
+  QString templateContent;  // Optional template content (Template mode only)
   QString fileTypeName;     // File type name (e.g., "Markdown", "Text")
+
+  NewNoteBodyMode bodyMode = NewNoteBodyMode::Template;
+  QString literalContent; // Verbatim body (LiteralContent mode only)
 };
 
 // Result structure for note creation.

--- a/src/data/core/Info.plist
+++ b/src/data/core/Info.plist
@@ -44,6 +44,28 @@
     <string>A pleasant note-taking platform</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
+    <key>NSServices</key>
+    <array>
+        <dict>
+            <key>NSMessage</key>
+            <string>createNoteFromSelection</string>
+            <key>NSPortName</key>
+            <string>VNote</string>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>Create Note in VNote</string>
+            </dict>
+            <key>NSSendTypes</key>
+            <array>
+                <string>public.utf8-plain-text</string>
+            </array>
+            <key>NSRequiredContext</key>
+            <dict/>
+            <key>NSRestricted</key>
+            <false/>
+        </dict>
+    </array>
     <key>NSSupportsAutomaticGraphicsSwitching</key>
     <true/>
     <key>NSRequiresAquaSystemAppearance</key>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,11 +41,11 @@
 #include <core/services/configservice.h>
 #include <core/services/eventbridge.h>
 #include <core/services/filetypecoreservice.h>
+#include <core/services/historyservice.h>
 #include <core/services/hookmanager.h>
 #include <core/services/htmltemplateservice.h>
 #include <core/services/imagehostservice.h>
 #include <core/services/notebookcoreservice.h>
-#include <core/services/historyservice.h>
 #include <core/services/notebookiogate.h>
 #include <core/services/notificationservice.h>
 #include <core/services/searchcoreservice.h>
@@ -68,8 +68,8 @@
 #include <core/updatelease.h>
 #include <core/vxcorelogbridge.h>
 #include <gui/services/navigationmodeservice.h>
-#include <gui/services/themeservice.h>
 #include <gui/services/stickerfactory.h>
+#include <gui/services/themeservice.h>
 #include <gui/services/viewwindowfactory.h>
 #include <gui/utils/widgetutils.h>
 #include <qwindow.h>
@@ -249,9 +249,8 @@ int main(int argc, char *argv[]) {
 
   {
     vnotex::UpdateLease::AcquireError leaseError = vnotex::UpdateLease::AcquireError::None;
-    vnotex::UpdateLease startupLease =
-        vnotex::UpdateLease::acquire(installDir, vnotex::UpdateLease::c_defaultTimeoutMs,
-                                     &leaseError);
+    vnotex::UpdateLease startupLease = vnotex::UpdateLease::acquire(
+        installDir, vnotex::UpdateLease::c_defaultTimeoutMs, &leaseError);
     if (!startupLease) {
       // FAIL CLOSED. Never fall through to initialization: another process may
       // be swapping binaries this one is about to use. No Qt exists yet, so the
@@ -359,8 +358,7 @@ int main(int argc, char *argv[]) {
   // Chromium logs, run with QTWEBENGINE_CHROMIUM_FLAGS=--enable-logging; to work
   // around a platform QtWebEngine crash, add flags like --single-process and
   // VNote will preserve them (issue #2705).
-  qputenv("QTWEBENGINE_CHROMIUM_FLAGS",
-          buildChromiumFlags(qgetenv("QTWEBENGINE_CHROMIUM_FLAGS")));
+  qputenv("QTWEBENGINE_CHROMIUM_FLAGS", buildChromiumFlags(qgetenv("QTWEBENGINE_CHROMIUM_FLAGS")));
 
   // Enable QtWebEngine remote debugging (DevTools) when --remote-debugging-port
   // is passed. On Qt 6 the bare argv switch is NOT honored by QtWebEngine; the
@@ -788,16 +786,22 @@ int main(int argc, char *argv[]) {
     // "Open with VNote" while VNote is already running, plus raise/show).
     QObject::connect(&guard, &SingleInstanceGuard::openFilesRequested, &mainWindow,
                      [&mainWindow](const QStringList &p_files) { mainWindow.openFiles(p_files); });
-    QObject::connect(&guard, &SingleInstanceGuard::openFilesDetachedRequested, &mainWindow,
-                     [&mainWindow](const QStringList &p_files) {
-                       mainWindow.openFiles(p_files, true);
-                     });
+    QObject::connect(
+        &guard, &SingleInstanceGuard::openFilesDetachedRequested, &mainWindow,
+        [&mainWindow](const QStringList &p_files) { mainWindow.openFiles(p_files, true); });
     QObject::connect(&guard, &SingleInstanceGuard::showRequested, &mainWindow,
                      &MainWindow2::showMainWindow);
 
     QObject::disconnect(pendingOpenConnection);
     QObject::disconnect(pendingDetachedConnection);
     QObject::disconnect(pendingShowConnection);
+
+    // macOS "Create Note in VNote" system Service. The receiver must be
+    // connected BEFORE the native provider is registered, because Apple may
+    // dispatch a request immediately after registration.
+    QObject::connect(
+        &app, &Application::captureNoteRequested, &mainWindow,
+        [&mainWindow](const QString &p_text) { mainWindow.requestNoteCapture(p_text); });
 
     if (cmdOptions.m_detachedView) {
       mainWindow.showMinimized();
@@ -818,6 +822,11 @@ int main(int argc, char *argv[]) {
     themeService.setBaseBackground(mainWindow.palette().color(QPalette::Base));
 
     mainWindow.kickOffPostInit(cmdOptions.m_pathsToOpen, cmdOptions.m_detachedView);
+
+    // Register the native Service provider only now: the startup flow is
+    // installed, so a request arriving immediately is queued by MainWindow2
+    // until post-init completes. No-op off macOS.
+    app.registerServiceProvider();
 
     // Run event loop
     ret = app.exec();

--- a/src/widgets/dialogs/newnotedialog2.cpp
+++ b/src/widgets/dialogs/newnotedialog2.cpp
@@ -2,29 +2,58 @@
 
 #include <QComboBox>
 #include <QFormLayout>
+#include <QPlainTextEdit>
+#include <QTextDocument>
 #include <QVBoxLayout>
 
 #include <controllers/newnotecontroller.h>
-#include <core/services/filetypecoreservice.h>
-#include <core/services/snippetcoreservice.h>
 #include <core/configmgr2.h>
-#include <core/widgetconfig.h>
 #include <core/servicelocator.h>
+#include <core/services/filetypecoreservice.h>
 #include <core/services/notebookcoreservice.h>
+#include <core/services/snippetcoreservice.h>
+#include <core/widgetconfig.h>
 #include <utils/pathutils.h>
 #include <utils/widgetutils.h>
 
-#include "../widgetsfactory.h"
 #include "../lineeditwithsnippet.h"
+#include "../widgetsfactory.h"
 #include "notetemplateselector.h"
 
 using namespace vnotex;
+
+namespace {
+// Tests look widgets up by object name, never by label text.
+const char *kContentEditName = "newNoteContentEdit";
+
+// Extract literal capture text WITHOUT QPlainTextEdit::toPlainText().
+//
+// toPlainText() is documented to rewrite U+00A0 (no-break space) into a plain
+// space and U+2028/U+2029 into LF, which would silently mutate captured text the
+// user never touched. toRawText() returns the document buffer untouched, so the
+// ONLY normalization applied here is the intended one: the document's own block
+// separators (which is where Qt's CRLF / lone-CR collapsing on insertion ends
+// up) become LF. Every other code point survives verbatim.
+QString literalTextOf(const QPlainTextEdit *p_edit) {
+  if (!p_edit || !p_edit->document()) {
+    return QString();
+  }
+
+  QString text = p_edit->document()->toRawText();
+  text.replace(QChar::ParagraphSeparator, QLatin1Char('\n'));
+  return text;
+}
+} // namespace
 
 QString NewNoteDialog2::s_lastTemplate;
 
 NewNoteDialog2::NewNoteDialog2(ServiceLocator &p_services, const NodeIdentifier &p_parentId,
                                QWidget *p_parent)
-    : ScrollDialog(p_parent), m_services(p_services), m_parentId(p_parentId) {
+    : NewNoteDialog2(p_services, p_parentId, Options(), p_parent) {}
+
+NewNoteDialog2::NewNoteDialog2(ServiceLocator &p_services, const NodeIdentifier &p_parentId,
+                               const Options &p_options, QWidget *p_parent)
+    : ScrollDialog(p_parent), m_services(p_services), m_parentId(p_parentId), m_options(p_options) {
   // Create controller.
   m_controller = new NewNoteController(m_services, this);
 
@@ -50,24 +79,32 @@ void NewNoteDialog2::setupUI() {
       m_fileTypeCombo->addItem(ft.m_displayName, ft.m_typeName);
     }
   }
-  connect(m_fileTypeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-          [this](int) {
-            if (!m_fileTypeComboMuted) {
-              updateNameForFileType();
-            }
-          });
+  connect(m_fileTypeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int) {
+    if (!m_fileTypeComboMuted) {
+      updateNameForFileType();
+    }
+  });
   layout->addRow(tr("Type:"), m_fileTypeCombo);
 
   // Name input.
   auto *snippetService = m_services.get<SnippetCoreService>();
   m_nameEdit = WidgetsFactory::createLineEditWithSnippet(snippetService, mainWidget);
-  connect(m_nameEdit, &QLineEdit::textEdited, this,
-          [this]() { updateFileTypeForName(); });
+  connect(m_nameEdit, &QLineEdit::textEdited, this, [this]() { updateFileTypeForName(); });
   layout->addRow(tr("Name:"), m_nameEdit);
 
-  // Template selector.
-  m_templateSelector = new NoteTemplateSelector(m_services, mainWidget);
-  layout->addRow(tr("Template:"), m_templateSelector);
+  // Body source: exactly one of the two controls exists.
+  if (m_options.m_bodyMode == BodyMode::LiteralContent) {
+    m_contentEdit = new QPlainTextEdit(mainWidget);
+    m_contentEdit->setObjectName(QLatin1String(kContentEditName));
+    // Verbatim: no trimming here or on accept. Qt collapses CRLF and lone CR
+    // into document block separators on insertion, which literalTextOf() then
+    // renders as LF -- that is the persistence policy for captured text.
+    m_contentEdit->setPlainText(m_options.m_initialContent);
+    layout->addRow(tr("Content:"), m_contentEdit);
+  } else {
+    m_templateSelector = new NoteTemplateSelector(m_services, mainWidget);
+    layout->addRow(tr("Template:"), m_templateSelector);
+  }
 
   setCentralWidget(mainWidget);
 
@@ -90,8 +127,9 @@ void NewNoteDialog2::initDefaultValues() {
   // Generate default name based on file type.
   updateNameForFileType();
 
-  // Restore last template.
-  if (!s_lastTemplate.isEmpty()) {
+  // Restore last template. Capture dialogs have no template selector and must
+  // neither read nor overwrite the shared last-template state.
+  if (m_templateSelector && !s_lastTemplate.isEmpty()) {
     if (!m_templateSelector->setCurrentTemplate(s_lastTemplate)) {
       s_lastTemplate.clear();
     }
@@ -100,7 +138,8 @@ void NewNoteDialog2::initDefaultValues() {
 
 void NewNoteDialog2::updateNameForFileType() {
   auto *fileTypeService = m_services.get<FileTypeCoreService>();
-  const auto fileType = fileTypeService->getFileTypeByName(m_fileTypeCombo->currentData().toString());
+  const auto fileType =
+      fileTypeService->getFileTypeByName(m_fileTypeCombo->currentData().toString());
 
   // Get current name and extract base name (without extension).
   QString currentName = m_nameEdit->text().trimmed();
@@ -143,9 +182,8 @@ void NewNoteDialog2::updateFileTypeForName() {
 }
 
 bool NewNoteDialog2::validateInputs() {
-  NoteValidationResult result =
-      m_controller->validateName(m_parentId.notebookId, m_parentId.relativePath,
-                                 m_nameEdit->evaluatedText().trimmed());
+  NoteValidationResult result = m_controller->validateName(
+      m_parentId.notebookId, m_parentId.relativePath, m_nameEdit->evaluatedText().trimmed());
 
   if (!result.valid) {
     setInformationText(result.message, ScrollDialog::InformationLevel::Error);
@@ -168,8 +206,10 @@ QString NewNoteDialog2::getPreferredSuffix() const {
 }
 
 void NewNoteDialog2::acceptedButtonClicked() {
-  // Save last template.
-  s_lastTemplate = m_templateSelector->getCurrentTemplate();
+  // Save last template (template mode only).
+  if (m_templateSelector) {
+    s_lastTemplate = m_templateSelector->getCurrentTemplate();
+  }
 
   // Save default file type (as type name string).
   QString fileTypeName = m_fileTypeCombo->currentData().toString();
@@ -184,8 +224,16 @@ void NewNoteDialog2::acceptedButtonClicked() {
   input.notebookId = m_parentId.notebookId;
   input.parentFolderPath = m_parentId.relativePath;
   input.name = m_nameEdit->evaluatedText().trimmed();
-  input.templateContent = m_templateSelector->getTemplateContent();
   input.fileTypeName = fileTypeName;
+
+  // The two body sources are never combined.
+  if (m_options.m_bodyMode == BodyMode::LiteralContent) {
+    input.bodyMode = NewNoteBodyMode::LiteralContent;
+    input.literalContent = literalTextOf(m_contentEdit);
+  } else {
+    input.templateContent =
+        m_templateSelector ? m_templateSelector->getTemplateContent() : QString();
+  }
 
   // Delegate to controller.
   NewNoteResult result = m_controller->createNote(input);

--- a/src/widgets/dialogs/newnotedialog2.h
+++ b/src/widgets/dialogs/newnotedialog2.h
@@ -6,6 +6,7 @@
 #include <core/nodeinfo.h>
 
 class QComboBox;
+class QPlainTextEdit;
 
 namespace vnotex {
 
@@ -22,15 +23,43 @@ class NewNoteDialog2 : public ScrollDialog {
   Q_OBJECT
 
 public:
-  // Create a note under the parent folder identified by p_parentId.
+  // Where the new note's body comes from. Control visibility is derived from
+  // the mode, so contradictory combinations cannot be expressed.
+  enum class BodyMode {
+    // Default: show the Template selector; its content is expanded through the
+    // snippet engine.
+    Template,
+    // Capture mode: show an editable Content field whose text is written
+    // verbatim, with no snippet/template interpretation.
+    LiteralContent
+  };
+
+  // Immutable dialog configuration. Defaults reproduce the ordinary New Note
+  // behavior exactly.
+  struct Options {
+    BodyMode m_bodyMode = BodyMode::Template;
+
+    // Only meaningful for BodyMode::LiteralContent.
+    QString m_initialContent;
+  };
+
+  // Create a note under the parent folder identified by p_parentId, using the
+  // default (template) options.
   NewNoteDialog2(ServiceLocator &p_services, const NodeIdentifier &p_parentId,
                  QWidget *p_parent = nullptr);
+
+  // Configured overload. There are deliberately no post-construction setters:
+  // the mode fixes which controls exist.
+  NewNoteDialog2(ServiceLocator &p_services, const NodeIdentifier &p_parentId,
+                 const Options &p_options, QWidget *p_parent = nullptr);
+
   ~NewNoteDialog2() override;
 
   // Get the identifier of the newly created note (valid after accept()).
   NodeIdentifier getNewNodeId() const;
 
   // Get the caret offset from a template "@@" mark (valid after accept()), or -1.
+  // In literal-content mode this is the end of the captured content.
   int getNewCursorOffset() const;
 
 protected:
@@ -57,13 +86,17 @@ private:
   ServiceLocator &m_services;
   NodeIdentifier m_parentId;
 
+  const Options m_options;
+
   // Controller handles validation and creation logic.
   NewNoteController *m_controller = nullptr;
 
   // UI widgets.
   LineEditWithSnippet *m_nameEdit = nullptr;
   QComboBox *m_fileTypeCombo = nullptr;
+  // Only one of these exists, per m_options.m_bodyMode.
   NoteTemplateSelector *m_templateSelector = nullptr;
+  QPlainTextEdit *m_contentEdit = nullptr;
 
   // Guard flag to prevent feedback loops between name↔type sync.
   bool m_fileTypeComboMuted = false;

--- a/src/widgets/mainwindow2.cpp
+++ b/src/widgets/mainwindow2.cpp
@@ -45,8 +45,8 @@
 #include <core/exportcontext.h>
 #include <core/fileopensettings.h>
 #include <core/hooknames.h>
-#include <core/nodeidentifier.h>
 #include <core/logging.h>
+#include <core/nodeidentifier.h>
 #include <core/servicelocator.h>
 #include <core/services/bufferservice.h>
 #include <core/services/hookmanager.h>
@@ -59,15 +59,17 @@
 
 #include <controllers/firstruncontroller.h>
 #include <controllers/notificationrouter.h>
-#include <controllers/updatecontroller.h>
 #include <controllers/searchcontroller.h>
 #include <controllers/syncconflictcontroller.h>
+#include <controllers/updatecontroller.h>
 #include <controllers/viewareacontroller.h>
 #include <qwebengineview.h>
 #include <unitedentry/unitedentrymgr.h>
 #include <views/inodeexplorer.h>
+#include <widgets/consoleviewer.h>
 #include <widgets/dialogs/exportdialog2.h>
 #include <widgets/locationlist2.h>
+#include <widgets/mainwindowtaskcontext.h>
 #include <widgets/messageboxhelper.h>
 #include <widgets/notebookexplorer2.h>
 #include <widgets/notebookselector2.h>
@@ -76,10 +78,8 @@
 #include <widgets/snippetpanel2.h>
 #include <widgets/tagexplorer2.h>
 #include <widgets/taskpanel2.h>
-#include <widgets/consoleviewer.h>
 #include <widgets/viewarea2.h>
 #include <widgets/viewwindow2.h>
-#include <widgets/mainwindowtaskcontext.h>
 
 #include <core/services/taskservice.h>
 
@@ -95,6 +95,8 @@ MainWindow2::MainWindow2(ServiceLocator &p_serviceLocator, QWidget *p_parent)
   setupUI();
 
   setAcceptDrops(true);
+
+  m_captureDispatcher.setHandler([this](const QString &p_text) { handleNoteCapture(p_text); });
 
   // Restore window geometry/state early so the window appears at the right
   // size and position.  View-area layout is deferred to kickOffPostInit()
@@ -451,6 +453,22 @@ void MainWindow2::drainPendingOpenBatches() {
   }
 }
 
+void MainWindow2::requestNoteCapture(const QString &p_text) { m_captureDispatcher.request(p_text); }
+
+void MainWindow2::handleNoteCapture(const QString &p_text) {
+  // The request comes from another process, so bring VNote forward first.
+  showMainWindow();
+
+  if (!m_notebookExplorer) {
+    qWarning() << "MainWindow2::handleNoteCapture: notebook explorer unavailable";
+    return;
+  }
+
+  // Blocks on a modal dialog; PendingCaptureDispatcher guarantees the next
+  // request is handled only after this returns.
+  m_notebookExplorer->captureNote(p_text);
+}
+
 void MainWindow2::restoreWindowGeometry() {
   const auto &sessionConfig = m_serviceLocator.get<ConfigMgr2>()->getSessionConfig();
   const auto sg = sessionConfig.getMainWindowStateGeometry();
@@ -689,6 +707,9 @@ void MainWindow2::setupViewArea() {
     // Drain queued opens in arrival order; detached batches each get a fresh
     // detached window.
     drainPendingOpenBatches();
+    // Only then release queued Service capture requests: a capture opens a
+    // buffer, which must land in the restored vxcore workspace.
+    m_captureDispatcher.setReady();
   });
 }
 
@@ -843,8 +864,7 @@ void MainWindow2::setupDocks() {
             disconnect(m_currentWindowNameConn);
             if (win) {
               m_currentWindowNameConn =
-                  connect(win, &ViewWindow2::nameChanged, this,
-                          [this]() { updateWindowTitle(); });
+                  connect(win, &ViewWindow2::nameChanged, this, [this]() { updateWindowTitle(); });
             }
             updateWindowTitle();
           });
@@ -904,18 +924,17 @@ void MainWindow2::setupDocks() {
 
     // Stream task output to the Console viewer, auto-showing the Console dock
     // whenever output arrives (i.e. when a task runs).
-    connect(taskService, &TaskService::taskOutputRequested, this,
-            [this](const QString &p_text) {
-              // Auto-show the Console dock only when it is hidden, so streaming
-              // output does not repeatedly steal focus.
-              auto *consoleDock = m_dockWidgetHelper.getDock(DockWidgetHelper::ConsoleDock);
-              if (consoleDock && !consoleDock->isVisible()) {
-                m_dockWidgetHelper.activateDock(DockWidgetHelper::ConsoleDock);
-              }
-              if (m_consoleViewer) {
-                m_consoleViewer->appendOutput(p_text);
-              }
-            });
+    connect(taskService, &TaskService::taskOutputRequested, this, [this](const QString &p_text) {
+      // Auto-show the Console dock only when it is hidden, so streaming
+      // output does not repeatedly steal focus.
+      auto *consoleDock = m_dockWidgetHelper.getDock(DockWidgetHelper::ConsoleDock);
+      if (consoleDock && !consoleDock->isVisible()) {
+        m_dockWidgetHelper.activateDock(DockWidgetHelper::ConsoleDock);
+      }
+      if (m_consoleViewer) {
+        m_consoleViewer->appendOutput(p_text);
+      }
+    });
 
     // Reload notebook-scoped tasks when the current notebook changes.
     connect(m_notebookExplorer, &NotebookExplorer2::currentNotebookChanged, taskService,
@@ -1318,8 +1337,8 @@ void MainWindow2::setupNotifications() {
   m_notificationRouter = new NotificationRouter(m_serviceLocator, this);
 
   if (m_notebookExplorer) {
-    connect(m_notebookExplorer, &NotebookExplorer2::syncUserMessageRequested,
-            m_notificationRouter, &NotificationRouter::onSyncUserMessageRequested);
+    connect(m_notebookExplorer, &NotebookExplorer2::syncUserMessageRequested, m_notificationRouter,
+            &NotificationRouter::onSyncUserMessageRequested);
     connect(m_notebookExplorer, &NotebookExplorer2::syncIncidentRetryRequested,
             m_notificationRouter, &NotificationRouter::onSyncIncidentRetryRequested);
     connect(m_notificationRouter, &NotificationRouter::openSyncInfoRequested, m_notebookExplorer,
@@ -1357,8 +1376,8 @@ void MainWindow2::setupCloseFocusedShortcut() {
   }
   const auto &coreConfig = configMgr->getCoreConfig();
 
-  auto *shortcut = WidgetUtils::createShortcut(
-      coreConfig.getShortcut(CoreConfig::Shortcut::CloseFocus), this);
+  auto *shortcut =
+      WidgetUtils::createShortcut(coreConfig.getShortcut(CoreConfig::Shortcut::CloseFocus), this);
   if (!shortcut) {
     return;
   }
@@ -1438,4 +1457,3 @@ void MainWindow2::onThemeChanged() {
     m_progressDialog->setValue(3);
   }
 }
-

--- a/src/widgets/mainwindow2.h
+++ b/src/widgets/mainwindow2.h
@@ -7,6 +7,8 @@
 #include <QStringList>
 #include <QVector>
 
+#include <functional>
+
 #include <core/noncopyable.h>
 #include <widgets/dockwidgethelper.h>
 
@@ -44,6 +46,76 @@ class FirstRunController;
 class UpdateController;
 class NotificationRouter;
 class NotificationToast;
+
+// Non-UI state machine behind MainWindow2's macOS Service note capture: a FIFO
+// of pending requests, a startup-readiness bit, and a reentrancy guard.
+//
+// It is deliberately independent of MainWindow2 (which merely owns one and
+// supplies the modal handler) so the queueing/serialization contract can be
+// unit-tested without constructing the full window. Defined inline because
+// there is no widgets static library: a test must not have to compile
+// mainwindow2.cpp (and its whole transitive widget graph) to exercise this.
+//
+// Semantics:
+//   - Requests received before setReady() are queued, never handled.
+//   - setReady() drains the queue in FIFO order and is idempotent.
+//   - A request that arrives while the handler is running (i.e. from inside a
+//     modal dialog's nested event loop) is appended and handled after the
+//     current one returns, so handler depth never exceeds one.
+class PendingCaptureDispatcher {
+public:
+  using Handler = std::function<void(const QString &)>;
+
+  void setHandler(Handler p_handler) { m_handler = std::move(p_handler); }
+
+  // Queue a capture request, draining immediately when already ready.
+  void request(const QString &p_text) {
+    m_pending.append(p_text);
+    if (m_ready) {
+      drain();
+    }
+  }
+
+  // Mark startup complete and drain whatever accumulated. Idempotent.
+  void setReady() {
+    if (m_ready) {
+      return;
+    }
+    m_ready = true;
+    drain();
+  }
+
+  bool isReady() const { return m_ready; }
+
+  int pendingCount() const { return m_pending.size(); }
+
+private:
+  void drain() {
+    if (m_draining) {
+      // A request arrived from inside the handler (the modal dialog's nested
+      // event loop). It is already queued; the outer loop will pick it up.
+      return;
+    }
+
+    m_draining = true;
+    while (!m_pending.isEmpty()) {
+      const QString text = m_pending.takeFirst();
+      if (m_handler) {
+        m_handler(text);
+      }
+    }
+    m_draining = false;
+  }
+
+  Handler m_handler;
+
+  QVector<QString> m_pending;
+
+  bool m_ready = false;
+
+  // True while drain() is running, so a nested request only appends.
+  bool m_draining = false;
+};
 
 // MainWindow2 is a minimal QMainWindow shell for the new clean architecture.
 // Receives ServiceLocator via constructor for dependency injection.
@@ -111,6 +183,11 @@ public:
   void restartForUpdate();
 
   void showMainWindow();
+
+  // Entry point for a macOS "Create Note in VNote" Service request. Queues the
+  // text until post-initialization completes, then serially opens one capture
+  // dialog per request.
+  void requestNoteCapture(const QString &p_text);
 
   void quitApp();
 
@@ -192,6 +269,11 @@ private:
   // after each batch, so every queued --detached-view invocation opens into its
   // own detached window without relying on timer-ordering.
   void drainPendingOpenBatches();
+
+  // Handle one dequeued capture request: foreground the window and run the
+  // explorer's capture flow (which is modal for the duration).
+  void handleNoteCapture(const QString &p_text);
+
   void setupSystemTray();
 
   // Create the notification toast (transient surface for Attention::Interrupt)
@@ -319,6 +401,10 @@ private:
   };
   QVector<PendingOpenBatch> m_pendingOpenBatches;
 
+  // macOS Service capture requests: queued until post-init completes, then
+  // handled one at a time.
+  PendingCaptureDispatcher m_captureDispatcher;
+
   // -1: do not request to quit;
   // 0 and above: exit code.
   int m_requestQuit = -1;
@@ -340,4 +426,3 @@ private:
 } // namespace vnotex
 
 #endif // MAINWINDOW2_H
-

--- a/src/widgets/notebookexplorer2.cpp
+++ b/src/widgets/notebookexplorer2.cpp
@@ -54,8 +54,8 @@
 #include <views/twocolumnsnodeexplorer.h>
 #include <vxcore/notebook_json_keys.h>
 // TODO: Migrate dialogs to use ServiceLocator DI pattern
-#include <core/services/templateservice.h>
 #include <core/services/snippetcoreservice.h>
+#include <core/services/templateservice.h>
 #include <widgets/dialogs/importfolderdialog2.h>
 #include <widgets/dialogs/managenotebooksdialog2.h>
 #include <widgets/dialogs/marknodedialog2.h>
@@ -188,12 +188,11 @@ NotebookExplorer2::NotebookExplorer2(ServiceLocator &p_services, QWidget *p_pare
               }
             });
     connect(syncSvc, &SyncService::syncFailed, this, &NotebookExplorer2::onSyncFailedSurface);
-    connect(syncSvc, &SyncService::enableFinished, this,
-            [this](const QString &, VxCoreError) {
-              // Failure-notification retirement on OK lives in
-              // NotificationRouter, which subscribes to this same signal.
-              updateSyncButtonState();
-            });
+    connect(syncSvc, &SyncService::enableFinished, this, [this](const QString &, VxCoreError) {
+      // Failure-notification retirement on OK lives in
+      // NotificationRouter, which subscribes to this same signal.
+      updateSyncButtonState();
+    });
     connect(syncSvc, &SyncService::credentialsSetFinished, this,
             [this](const QString &p_notebookId, VxCoreError p_result) {
               if (p_result == VXCORE_OK) {
@@ -1533,6 +1532,34 @@ void NotebookExplorer2::setNodeViewOrder(ViewOrder p_order) {
 // --- GUI request handlers from controller signals ---
 
 void NotebookExplorer2::onNewNoteRequested(const NodeIdentifier &p_parentId) {
+  doNewNote(p_parentId, NewNoteDialog2::Options());
+}
+
+void NotebookExplorer2::captureNote(const QString &p_text) {
+  NodeIdentifier parentId = currentExploredFolderId();
+  if (!parentId.isValid()) {
+    MessageBoxHelper::notify(MessageBoxHelper::Information,
+                             tr("Please first create a notebook to hold your data."), window());
+    return;
+  }
+
+  // Unlike the toolbar actions, an externally initiated request must never be
+  // silently dropped: tell the user why nothing happened.
+  if (isCurrentNotebookReadOnly()) {
+    MessageBoxHelper::notify(MessageBoxHelper::Warning,
+                             tr("The current notebook is read-only, so the note was not created."),
+                             window());
+    return;
+  }
+
+  NewNoteDialog2::Options options;
+  options.m_bodyMode = NewNoteDialog2::BodyMode::LiteralContent;
+  options.m_initialContent = p_text;
+  doNewNote(parentId, options);
+}
+
+void NotebookExplorer2::doNewNote(const NodeIdentifier &p_parentId,
+                                  const NewNoteDialog2::Options &p_options) {
   // Suppress the fs-watcher's delayed reload for this parent: we perform the
   // model refresh synchronously below and need the selection to survive past
   // the watcher's 500 ms debounce window.
@@ -1542,7 +1569,7 @@ void NotebookExplorer2::onNewNoteRequested(const NodeIdentifier &p_parentId) {
     expectFsChange(parentAbsPath);
   }
 
-  NewNoteDialog2 dialog(m_services, p_parentId, window());
+  NewNoteDialog2 dialog(m_services, p_parentId, p_options, window());
   if (dialog.exec() == QDialog::Accepted) {
     NodeIdentifier newNodeId = dialog.getNewNodeId();
     if (newNodeId.isValid()) {
@@ -1555,6 +1582,7 @@ void NotebookExplorer2::onNewNoteRequested(const NodeIdentifier &p_parentId) {
         settings.m_mode = ViewWindowMode::Edit;
         settings.m_forceMode = true;
         settings.m_newFile = true;
+        // In capture mode this is the end of the captured content.
         settings.m_cursorOffset = dialog.getNewCursorOffset();
         bufferSvc->openBuffer(newNodeId, settings);
       }

--- a/src/widgets/notebookexplorer2.h
+++ b/src/widgets/notebookexplorer2.h
@@ -13,6 +13,7 @@
 #include <nodeinfo.h>
 #include <views/inodeexplorer.h>
 #include <vxcore/vxcore_types.h>
+#include <widgets/dialogs/newnotedialog2.h>
 
 class QAction;
 class QFileSystemWatcher;
@@ -95,6 +96,12 @@ public slots:
   void newFolder();
   void newNote();
   void newQuickNote();
+
+  // Create a note pre-filled with externally captured text (macOS "Create Note
+  // in VNote" Service). Resolves the destination at handling time and surfaces
+  // a visible error for a missing or read-only destination, because an
+  // external request must never fail silently. Blocks on the modal dialog.
+  void captureNote(const QString &p_text);
 
   // Import operations - use current explored folder as parent
   void importFile();
@@ -218,6 +225,12 @@ private:
   // Import file/folder helpers (called from toolbar actions)
   void onImportFilesRequested(const NodeIdentifier &p_targetFolderId);
   void onImportFolderRequested(const NodeIdentifier &p_targetFolderId);
+
+  // Shared body of the New Note flow: fs-change suppression, modal dialog with
+  // the given options, parent reload, selection, and buffer open in edit mode.
+  // Ordinary New Note passes default options; Service capture passes
+  // literal-content options.
+  void doNewNote(const NodeIdentifier &p_parentId, const NewNoteDialog2::Options &p_options);
   void setCurrentNotebookInternal(const QString &p_notebookId);
   // Functional read-only guard for toolbar-driven mutation slots. Resolves the
   // current notebook id the same way the read-only badge does and queries

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,3 +97,52 @@ add_subdirectory(gui)
 add_subdirectory(export)
 add_subdirectory(unitedentry)
 add_subdirectory(integration)
+
+# =============================================================================
+# macOS Services metadata (Create Note in VNote)
+# =============================================================================
+# Asserted against the FINAL BUNDLE plist, not the source file: the bundle is
+# what macOS actually reads, and it is produced through MACOSX_BUNDLE_INFO_PLIST
+# (src/CMakeLists.txt). Exact raw values and types are pinned, because a
+# silently mistyped key (e.g. NSRestricted as a string) still lints clean while
+# breaking Service discovery.
+if(APPLE)
+  set(VX_BUNDLE_PLIST "$<TARGET_BUNDLE_DIR:vnote>/Contents/Info.plist")
+
+  # Helper: assert one plist key resolves to one exact raw value.
+  function(add_service_plist_test NAME KEYPATH EXPECTED)
+    add_test(NAME test_macos_service_plist_${NAME}
+      COMMAND plutil -extract "${KEYPATH}" raw -o - "${VX_BUNDLE_PLIST}")
+    set_tests_properties(test_macos_service_plist_${NAME} PROPERTIES
+      PASS_REGULAR_EXPRESSION "^${EXPECTED}\n?$"
+      TIMEOUT 60
+    )
+  endfunction()
+
+  add_service_plist_test(nsmessage "NSServices.0.NSMessage" "createNoteFromSelection")
+  add_service_plist_test(nsportname "NSServices.0.NSPortName" "VNote")
+  add_service_plist_test(nsmenuitem_default "NSServices.0.NSMenuItem.default"
+                         "Create Note in VNote")
+  add_service_plist_test(nssendtypes_0 "NSServices.0.NSSendTypes.0"
+                         "public.utf8-plain-text")
+  # Boolean, not the string "false": a mistyped value still lints clean.
+  add_service_plist_test(nsrestricted "NSServices.0.NSRestricted" "false")
+
+  # NSRequiredContext must be a dictionary (an empty one), and NSReturnTypes
+  # must be ABSENT because the Service returns nothing.
+  add_test(NAME test_macos_service_plist_nsrequiredcontext_is_dict
+    COMMAND /usr/libexec/PlistBuddy -c "Print :NSServices:0:NSRequiredContext"
+            "${VX_BUNDLE_PLIST}")
+  set_tests_properties(test_macos_service_plist_nsrequiredcontext_is_dict PROPERTIES
+    PASS_REGULAR_EXPRESSION "Dict"
+    TIMEOUT 60
+  )
+
+  add_test(NAME test_macos_service_plist_no_nsreturntypes
+    COMMAND /usr/libexec/PlistBuddy -c "Print :NSServices:0:NSReturnTypes"
+            "${VX_BUNDLE_PLIST}")
+  set_tests_properties(test_macos_service_plist_no_nsreturntypes PROPERTIES
+    WILL_FAIL TRUE
+    TIMEOUT 60
+  )
+endif()

--- a/tests/controllers/test_newnotecontroller.cpp
+++ b/tests/controllers/test_newnotecontroller.cpp
@@ -3,15 +3,15 @@
 #include <QFile>
 #include <QJsonObject>
 
-#include <vxcore/vxcore.h>
 #include <vxcore/notebook_json_keys.h>
+#include <vxcore/vxcore.h>
 
 #include <controllers/newnotecontroller.h>
 #include <core/servicelocator.h>
 #include <core/services/notebookcoreservice.h>
 #include <core/services/snippetcoreservice.h>
-#include <utils/pathutils.h>
 #include <temp_dir_fixture.h>
+#include <utils/pathutils.h>
 
 using namespace vnotex;
 
@@ -27,12 +27,15 @@ private slots:
   void testCreateNoteWithCursorMark();
   void testCreateNoteWithoutCursorMark();
   void testCreateNoteOverrides();
+  void testCreateNoteLiteralContentIsVerbatim();
+  void testCreateNoteLiteralContentCleared();
   void testCreateQuickNoteExpandsBody();
   void testCreateQuickNoteSequencedOverrides();
   void testCreateQuickNoteMissingNotebook();
 
 private:
   QString readNote(const NodeIdentifier &p_id) const;
+  QByteArray readNoteBytes(const NodeIdentifier &p_id) const;
 
   VxCoreContextHandle m_context = nullptr;
   NotebookCoreService *m_notebookService = nullptr;
@@ -57,8 +60,8 @@ void TestNewNoteController::initTestCase() {
 
   // Create an empty-dir bundled notebook to host the notes.
   QString root = m_tempDir.createDir("nb_root");
-  m_notebookId = m_notebookService->createNotebook(root, QStringLiteral("{}"),
-                                                   NotebookType::Bundled);
+  m_notebookId =
+      m_notebookService->createNotebook(root, QStringLiteral("{}"), NotebookType::Bundled);
   QVERIFY(!m_notebookId.isEmpty());
 }
 
@@ -74,14 +77,18 @@ void TestNewNoteController::cleanupTestCase() {
 }
 
 QString TestNewNoteController::readNote(const NodeIdentifier &p_id) const {
+  return QString::fromUtf8(readNoteBytes(p_id));
+}
+
+QByteArray TestNewNoteController::readNoteBytes(const NodeIdentifier &p_id) const {
   QJsonObject cfg = m_notebookService->getNotebookConfig(p_id.notebookId);
   QString root = cfg.value(QLatin1String(vxcore::kJsonKeyRootFolder)).toString();
   QString fullPath = PathUtils::concatenateFilePath(root, p_id.relativePath);
   QFile f(fullPath);
   if (!f.open(QIODevice::ReadOnly)) {
-    return QString();
+    return QByteArray();
   }
-  QString content = QString::fromUtf8(f.readAll());
+  QByteArray content = f.readAll();
   f.close();
   return content;
 }
@@ -124,6 +131,53 @@ void TestNewNoteController::testCreateNoteOverrides() {
   NewNoteResult result = controller.createNote(input);
   QVERIFY2(result.success, qPrintable(result.errorMessage));
   QCOMPARE(readNote(result.nodeId), QStringLiteral("file mynote.md base mynote"));
+}
+
+// Literal capture (macOS Services): the controller must persist the dialog text
+// byte-for-byte. Nothing in it may be interpreted as a snippet, a magic symbol,
+// a cursor mark or a selection mark, and no whitespace may be trimmed.
+void TestNewNoteController::testCreateNoteLiteralContentIsVerbatim() {
+  NewNoteController controller(m_services);
+
+  // Already LF-normalized (QPlainTextEdit owns CRLF -> LF), with leading and
+  // trailing spaces, a tab, a supplementary-plane character, and every marker
+  // the template path would otherwise consume.
+  const QString captured = QStringLiteral("  lead\tspaced\n%note% %no% @@ $$\n\U0001F4DD end  ");
+
+  NewNoteInput input;
+  input.notebookId = m_notebookId;
+  input.name = QStringLiteral("literal.md");
+  input.bodyMode = NewNoteBodyMode::LiteralContent;
+  input.literalContent = captured;
+  // A stale templateContent must be ignored in literal mode.
+  input.templateContent = QStringLiteral("SHOULD NOT BE WRITTEN");
+
+  NewNoteResult result = controller.createNote(input);
+  QVERIFY2(result.success, qPrintable(result.errorMessage));
+
+  // Raw bytes must match the controller input exactly.
+  QCOMPARE(readNoteBytes(result.nodeId), captured.toUtf8());
+
+  // Caret lands at the end of the captured text. Qt offsets are UTF-16 units,
+  // so the supplementary character counts as two.
+  QCOMPARE(result.cursorOffset, captured.size());
+}
+
+// A user who clears the Content field gets an empty note and a zero offset --
+// not the "no content" (-1) sentinel of the template path.
+void TestNewNoteController::testCreateNoteLiteralContentCleared() {
+  NewNoteController controller(m_services);
+
+  NewNoteInput input;
+  input.notebookId = m_notebookId;
+  input.name = QStringLiteral("literal_cleared.md");
+  input.bodyMode = NewNoteBodyMode::LiteralContent;
+  input.literalContent = QString();
+
+  NewNoteResult result = controller.createNote(input);
+  QVERIFY2(result.success, qPrintable(result.errorMessage));
+  QCOMPARE(readNoteBytes(result.nodeId), QByteArray());
+  QCOMPARE(result.cursorOffset, 0);
 }
 
 void TestNewNoteController::testCreateQuickNoteExpandsBody() {

--- a/tests/widgets/CMakeLists.txt
+++ b/tests/widgets/CMakeLists.txt
@@ -92,6 +92,12 @@ add_qt_test(test_notebooknodeview_state
     Qt6::Widgets
 )
 
+# NotebookExplorer2 session-state wire format PLUS MainWindow2's
+# PendingCaptureDispatcher (the FIFO / readiness / reentrancy state machine
+# behind the macOS "Create Note in VNote" Service). Neither needs the widgets
+# themselves: the state format is asserted against the raw QDataStream bytes and
+# the dispatcher is defined inline in mainwindow2.h, so mainwindow2.cpp (and its
+# whole transitive widget graph) is deliberately NOT compiled here.
 add_qt_test(test_notebookexplorer2_state
   SOURCES
     test_notebookexplorer2_state.cpp
@@ -522,10 +528,18 @@ add_custom_command(TARGET test_notebookexplorer2_multiselect POST_BUILD
 # Mirrors the source list of test_notebooksyncinfodialog2 with the addition of
 # locationinputwithbrowsebutton.cpp (the local-mode root folder picker) and
 # opennotebookcontroller.cpp (the controller the dialog instantiates).
+#
+# Also hosts the NewNoteDialog2 constructor-options coverage (macOS Services
+# note capture), which reuses this harness's fully wired ServiceLocator: hence
+# newnotedialog2.cpp + notetemplateselector.cpp + newnotecontroller.cpp, and
+# core_configs for ConfigMgr2/WidgetConfig. fileutils2.cpp is no longer compiled
+# inline because core_configs already provides it.
 add_qt_test(test_open_notebook_dialog2
   SOURCES
     test_open_notebook_dialog2.cpp
     ${CMAKE_SOURCE_DIR}/src/widgets/dialogs/opennotebookdialog2.cpp
+    ${CMAKE_SOURCE_DIR}/src/widgets/dialogs/newnotedialog2.cpp
+    ${CMAKE_SOURCE_DIR}/src/widgets/dialogs/notetemplateselector.cpp
     ${CMAKE_SOURCE_DIR}/src/widgets/dialogs/scrolldialog.cpp
     ${CMAKE_SOURCE_DIR}/src/widgets/dialogs/dialog.cpp
     ${CMAKE_SOURCE_DIR}/src/widgets/locationinputwithbrowsebutton.cpp
@@ -537,12 +551,13 @@ add_qt_test(test_open_notebook_dialog2
     ${CMAKE_SOURCE_DIR}/src/widgets/messageboxhelper.cpp
     ${CMAKE_SOURCE_DIR}/src/gui/utils/widgetutils.cpp
     ${CMAKE_SOURCE_DIR}/src/controllers/opennotebookcontroller.cpp
-    ${CMAKE_SOURCE_DIR}/src/utils/fileutils2.cpp
+    ${CMAKE_SOURCE_DIR}/src/controllers/newnotecontroller.cpp
     ${CMAKE_SOURCE_DIR}/src/utils/pathutils.cpp
     ${CMAKE_SOURCE_DIR}/src/core/error.cpp
   LINKS
     Qt6::Concurrent
     core_services
+    core_configs
     vxcore
     VTextEdit
     Qt6::Widgets

--- a/tests/widgets/test_notebookexplorer2_state.cpp
+++ b/tests/widgets/test_notebookexplorer2_state.cpp
@@ -1,15 +1,22 @@
 // Tests for NotebookExplorer2 saveState()/restoreState() serialization protocol.
 // We test the QDataStream wire format directly (without instantiating NotebookExplorer2)
 // because the widget has heavy GUI dependencies (ThemeService, ConfigMgr2, etc.).
+//
+// Also covers MainWindow2's PendingCaptureDispatcher: the non-UI FIFO /
+// readiness / reentrancy state machine behind the macOS "Create Note in VNote"
+// Service. It is a standalone class in mainwindow2.h precisely so this can be
+// asserted without constructing MainWindow2 (which needs the full service graph).
 
 #include <QtTest>
 
 #include <QByteArray>
 #include <QDataStream>
 #include <QHash>
+#include <QStringList>
 
 #include <core/nodeidentifier.h>
 #include <views/inodeexplorer.h>
+#include <widgets/mainwindow2.h>
 
 using namespace vnotex;
 
@@ -95,6 +102,12 @@ private slots:
   void testOldFormatCompatibility();
   void testEmptyData();
   void testNodeExplorerStateStreamRoundTrip();
+
+  // PendingCaptureDispatcher (macOS Service note capture).
+  void testCaptureQueuedUntilReady();
+  void testCaptureDrainsFifoOnReady();
+  void testCaptureNeverNestsHandler();
+  void testCapturePostReadyDrainsImmediately();
 };
 
 void TestNotebookExplorer2State::testRoundTrip_emptyCache() {
@@ -195,6 +208,97 @@ void TestNotebookExplorer2State::testNodeExplorerStateStreamRoundTrip() {
   QCOMPARE(restored.currentNodeId, id1);
   QCOMPARE(restored.displayRootId.notebookId, QStringLiteral("abc"));
   QCOMPARE(restored.displayRootId.relativePath, QStringLiteral("x"));
+}
+
+// =============================================================================
+// PendingCaptureDispatcher
+// =============================================================================
+
+// Requests arriving before post-init completes are queued, never handled: a
+// capture opens a buffer, which must land in the restored vxcore workspace.
+void TestNotebookExplorer2State::testCaptureQueuedUntilReady() {
+  PendingCaptureDispatcher dispatcher;
+  QStringList handled;
+  dispatcher.setHandler([&handled](const QString &p_text) { handled.append(p_text); });
+
+  QVERIFY(!dispatcher.isReady());
+
+  dispatcher.request(QStringLiteral("A"));
+  dispatcher.request(QStringLiteral("B"));
+
+  QCOMPARE(handled.size(), 0);
+  QCOMPARE(dispatcher.pendingCount(), 2);
+}
+
+// setReady() drains in arrival order and is idempotent.
+void TestNotebookExplorer2State::testCaptureDrainsFifoOnReady() {
+  PendingCaptureDispatcher dispatcher;
+  QStringList handled;
+  dispatcher.setHandler([&handled](const QString &p_text) { handled.append(p_text); });
+
+  dispatcher.request(QStringLiteral("A"));
+  dispatcher.request(QStringLiteral("B"));
+  dispatcher.request(QStringLiteral("C"));
+
+  dispatcher.setReady();
+
+  QVERIFY(dispatcher.isReady());
+  QCOMPARE(dispatcher.pendingCount(), 0);
+  QCOMPARE(handled, QStringList({QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")}));
+
+  // A second setReady() must not re-handle anything.
+  dispatcher.setReady();
+  QCOMPARE(handled.size(), 3);
+}
+
+// A request arriving while the handler runs (i.e. from inside the modal
+// dialog's nested event loop) must NOT open a nested dialog: handler depth
+// stays at one, and B runs only after A returns.
+void TestNotebookExplorer2State::testCaptureNeverNestsHandler() {
+  PendingCaptureDispatcher dispatcher;
+  QStringList entered;
+  QStringList exited;
+  int depth = 0;
+  int maxDepth = 0;
+
+  dispatcher.setHandler([&](const QString &p_text) {
+    ++depth;
+    maxDepth = qMax(maxDepth, depth);
+    entered.append(p_text);
+
+    // Simulate the Service firing again while A's dialog is up.
+    if (p_text == QStringLiteral("A")) {
+      dispatcher.request(QStringLiteral("B"));
+      // B must not have been handled re-entrantly.
+      QCOMPARE(entered.size(), 1);
+    }
+
+    exited.append(p_text);
+    --depth;
+  });
+
+  dispatcher.setReady();
+  dispatcher.request(QStringLiteral("A"));
+
+  QCOMPARE(maxDepth, 1);
+  QCOMPARE(entered, QStringList({QStringLiteral("A"), QStringLiteral("B")}));
+  QCOMPARE(exited, QStringList({QStringLiteral("A"), QStringLiteral("B")}));
+  QCOMPARE(dispatcher.pendingCount(), 0);
+}
+
+// Once ready, a request is handled straight away rather than accumulating.
+void TestNotebookExplorer2State::testCapturePostReadyDrainsImmediately() {
+  PendingCaptureDispatcher dispatcher;
+  QStringList handled;
+  dispatcher.setHandler([&handled](const QString &p_text) { handled.append(p_text); });
+
+  dispatcher.setReady();
+  QCOMPARE(handled.size(), 0);
+
+  dispatcher.request(QStringLiteral("only"));
+
+  QCOMPARE(handled, QStringList({QStringLiteral("only")}));
+  QCOMPARE(dispatcher.pendingCount(), 0);
 }
 
 } // namespace tests

--- a/tests/widgets/test_open_notebook_dialog2.cpp
+++ b/tests/widgets/test_open_notebook_dialog2.cpp
@@ -12,29 +12,47 @@
 //      destination enables the Open button; an existing non-empty path
 //      disables it (refine-open-notebook-dialog: relaxed dest contract).
 //
+// This file also hosts the NewNoteDialog2 constructor-options coverage (macOS
+// Services note capture) because it already owns a fully wired ServiceLocator +
+// QApplication dialog harness, plus the platform-independent
+// Application::dispatchCaptureText seam the native provider delegates to.
+//
 // Per ADR-9 patterns used in adjacent dialog tests (test_notebooksyncinfodialog2):
 // the dialog is instantiated directly with a ServiceLocator wired to a real
 // vxcore context (test mode). No actual notebook is opened in these subtests.
 
 #include <QApplication>
 #include <QButtonGroup>
+#include <QComboBox>
 #include <QDialogButtonBox>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QJsonObject>
 #include <QLineEdit>
+#include <QPlainTextEdit>
 #include <QPushButton>
 #include <QRadioButton>
 #include <QSignalSpy>
 #include <QStackedWidget>
 #include <QtTest>
 
+#include <application.h>
+#include <core/configmgr2.h>
 #include <core/servicelocator.h>
+#include <core/services/configcoreservice.h>
+#include <core/services/filetypecoreservice.h>
 #include <core/services/notebookcoreservice.h>
+#include <core/services/snippetcoreservice.h>
+#include <core/services/templateservice.h>
 #include <temp_dir_fixture.h>
+#include <widgets/dialogs/newnotedialog2.h>
+#include <widgets/dialogs/notetemplateselector.h>
 #include <widgets/dialogs/opennotebookdialog2.h>
+#include <widgets/lineeditwithsnippet.h>
 #include <widgets/locationinputwithbrowsebutton.h>
 
+#include <vxcore/notebook_json_keys.h>
 #include <vxcore/vxcore.h>
 #include <vxcore/vxcore_types.h>
 
@@ -64,6 +82,18 @@ private slots:
   //    existing-empty) -> Open enabled. Non-empty existing dest -> disabled.
   void testValidRemoteUrlEnablesOpenButton();
 
+  // --- NewNoteDialog2 constructor options (macOS Services note capture) ---
+  void testNewNoteDefaultOptionsKeepTemplate();
+  void testNewNoteLiteralOptionsShowEditableContent();
+  void testNewNoteLiteralAcceptPersistsVerbatim();
+  void testNewNoteLiteralClearedAcceptPersistsEmpty();
+  void testNewNoteLiteralDoesNotTouchLastTemplate();
+
+  // --- Application::dispatchCaptureText seam ---
+  void testDispatchRejectsMissingAndWhitespaceOnly();
+  void testDispatchAcceptsTextVerbatim();
+  void testDispatchWithoutCallbackIsRefused();
+
 private:
   // Build a ServiceLocator with a real NotebookCoreService bound to the shared
   // vxcore context. Each subtest is isolated because no actual notebooks are
@@ -71,7 +101,29 @@ private:
   // touch it, and local mode is not exercised through accept() here).
   void buildServices(ServiceLocator &services, NotebookCoreService *&svc);
 
+  // Parent folder (notebook root) the NewNoteDialog2 subtests create into.
+  NodeIdentifier newNoteParentId() const;
+
+  // Raw on-disk bytes of a created note, so persistence is asserted rather than
+  // the widget's own displayed text.
+  QByteArray readNoteBytes(const NodeIdentifier &p_id) const;
+
+  // Drive a constructed dialog to accept with the given note name.
+  void acceptNewNoteDialog(NewNoteDialog2 &p_dialog, const QString &p_name);
+
   VxCoreContextHandle m_ctx = nullptr;
+
+  // Fully wired service graph for the NewNoteDialog2 subtests. Owned here so a
+  // dialog can actually be accepted (which needs config + notebook services).
+  ServiceLocator m_newNoteServices;
+  ConfigCoreService *m_configCore = nullptr;
+  ConfigMgr2 *m_configMgr = nullptr;
+  NotebookCoreService *m_newNoteNotebookSvc = nullptr;
+  FileTypeCoreService *m_fileTypeSvc = nullptr;
+  SnippetCoreService *m_snippetSvc = nullptr;
+  TemplateService *m_templateSvc = nullptr;
+  TempDirFixture m_newNoteTempDir;
+  QString m_newNoteNotebookId;
 };
 
 void TestOpenNotebookDialog2::initTestCase() {
@@ -80,13 +132,85 @@ void TestOpenNotebookDialog2::initTestCase() {
   vxcore_set_test_mode(1);
   QCOMPARE(vxcore_context_create("{}", &m_ctx), VXCORE_OK);
   QVERIFY(m_ctx != nullptr);
+
+  // Service graph for the NewNoteDialog2 subtests.
+  QVERIFY(m_newNoteTempDir.isValid());
+
+  m_configCore = new ConfigCoreService(m_ctx);
+  m_configMgr = new ConfigMgr2(m_configCore);
+  // Required so getWidgetConfig() works inside the dialog; skipping it crashes
+  // that path (same rationale as test_node_explorer_reload_expansion).
+  m_configMgr->init();
+
+  m_newNoteNotebookSvc = new NotebookCoreService(m_ctx);
+  m_fileTypeSvc = new FileTypeCoreService(m_ctx, QStringLiteral("en_US"));
+  m_snippetSvc = new SnippetCoreService(m_ctx);
+  m_templateSvc = new TemplateService(m_configMgr);
+
+  m_newNoteServices.registerService<ConfigCoreService>(m_configCore);
+  m_newNoteServices.registerService<ConfigMgr2>(m_configMgr);
+  m_newNoteServices.registerService<NotebookCoreService>(m_newNoteNotebookSvc);
+  m_newNoteServices.registerService<FileTypeCoreService>(m_fileTypeSvc);
+  m_newNoteServices.registerService<SnippetCoreService>(m_snippetSvc);
+  m_newNoteServices.registerService<TemplateService>(m_templateSvc);
+
+  const QString root = m_newNoteTempDir.createDir("capture_nb");
+  m_newNoteNotebookId =
+      m_newNoteNotebookSvc->createNotebook(root, QStringLiteral("{}"), NotebookType::Bundled);
+  QVERIFY(!m_newNoteNotebookId.isEmpty());
 }
 
 void TestOpenNotebookDialog2::cleanupTestCase() {
+  delete m_templateSvc;
+  m_templateSvc = nullptr;
+  delete m_snippetSvc;
+  m_snippetSvc = nullptr;
+  delete m_fileTypeSvc;
+  m_fileTypeSvc = nullptr;
+  delete m_newNoteNotebookSvc;
+  m_newNoteNotebookSvc = nullptr;
+  delete m_configMgr;
+  m_configMgr = nullptr;
+  delete m_configCore;
+  m_configCore = nullptr;
+
   if (m_ctx) {
     vxcore_context_destroy(m_ctx);
     m_ctx = nullptr;
   }
+}
+
+NodeIdentifier TestOpenNotebookDialog2::newNoteParentId() const {
+  NodeIdentifier id;
+  id.notebookId = m_newNoteNotebookId;
+  id.relativePath = QString();
+  return id;
+}
+
+QByteArray TestOpenNotebookDialog2::readNoteBytes(const NodeIdentifier &p_id) const {
+  const QJsonObject cfg = m_newNoteNotebookSvc->getNotebookConfig(p_id.notebookId);
+  const QString root = cfg.value(QLatin1String(vxcore::kJsonKeyRootFolder)).toString();
+  QFile f(QDir(root).filePath(p_id.relativePath));
+  if (!f.open(QIODevice::ReadOnly)) {
+    return QByteArray();
+  }
+  const QByteArray content = f.readAll();
+  f.close();
+  return content;
+}
+
+void TestOpenNotebookDialog2::acceptNewNoteDialog(NewNoteDialog2 &p_dialog, const QString &p_name) {
+  auto *nameEdit = p_dialog.findChild<LineEditWithSnippet *>();
+  QVERIFY(nameEdit);
+  nameEdit->setText(p_name);
+
+  auto *box = p_dialog.getDialogButtonBox();
+  QVERIFY(box);
+  auto *okBtn = box->button(QDialogButtonBox::Ok);
+  QVERIFY(okBtn);
+  okBtn->click();
+  QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+  QCOMPARE(p_dialog.result(), static_cast<int>(QDialog::Accepted));
 }
 
 void TestOpenNotebookDialog2::buildServices(ServiceLocator &services, NotebookCoreService *&svc) {
@@ -316,6 +440,207 @@ void TestOpenNotebookDialog2::testValidRemoteUrlEnablesOpenButton() {
            "Open must be DISABLED when dest is an existing non-empty directory");
 
   delete svc;
+}
+
+// =============================================================================
+// NewNoteDialog2 constructor options.
+//
+// The macOS "Create Note in VNote" Service opens the ordinary New Note dialog
+// in a literal-content mode. The mode is fixed at construction (there are no
+// setters), so these subtests assert per-mode control existence and content
+// handling. Persistence itself is the controller's job and is covered by
+// tests/controllers/test_newnotecontroller.cpp.
+// =============================================================================
+
+// Default options must reproduce today's New Note dialog exactly: Template
+// selector present, no Content field.
+void TestOpenNotebookDialog2::testNewNoteDefaultOptionsKeepTemplate() {
+  NewNoteDialog2 dialog(m_newNoteServices, newNoteParentId());
+  QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+
+  QVERIFY2(dialog.findChild<NoteTemplateSelector *>() != nullptr,
+           "Default options must still show the template selector");
+  QVERIFY2(dialog.findChild<QPlainTextEdit *>(QStringLiteral("newNoteContentEdit")) == nullptr,
+           "Default options must NOT show a Content field");
+}
+
+// Capture options must expose an editable, named Content field seeded verbatim
+// (no trimming) and must NOT construct the template selector.
+void TestOpenNotebookDialog2::testNewNoteLiteralOptionsShowEditableContent() {
+  // Leading/trailing whitespace, a tab, and snippet markers that the template
+  // path would otherwise consume.
+  const QString captured = QStringLiteral("  lead\tkeep %note% @@ $$ trail  ");
+
+  NewNoteDialog2::Options options;
+  options.m_bodyMode = NewNoteDialog2::BodyMode::LiteralContent;
+  options.m_initialContent = captured;
+
+  NewNoteDialog2 dialog(m_newNoteServices, newNoteParentId(), options);
+  QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+
+  auto *contentEdit = dialog.findChild<QPlainTextEdit *>(QStringLiteral("newNoteContentEdit"));
+  QVERIFY2(contentEdit, "Content field must exist with object name 'newNoteContentEdit'");
+  QVERIFY2(contentEdit->isEnabled(), "Content field must be enabled");
+  QVERIFY2(!contentEdit->isReadOnly(), "Content field must be editable");
+  QCOMPARE(contentEdit->toPlainText(), captured);
+
+  QVERIFY2(dialog.findChild<NoteTemplateSelector *>() == nullptr,
+           "Capture options must NOT construct the template selector");
+}
+
+// End-to-end through the REAL dialog -> NewNoteInput -> NewNoteController ->
+// file path. Asserts the persisted bytes, not the widget's displayed text, so
+// an accidental trim / template-mode forwarding / snippet expansion would fail
+// here.
+//
+// Exactly one mutation is permitted: CRLF and lone CR collapse to LF. In
+// particular U+00A0 must survive, which QPlainTextEdit::toPlainText() would
+// silently rewrite to a plain space.
+void TestOpenNotebookDialog2::testNewNoteLiteralAcceptPersistsVerbatim() {
+  const QString captured =
+      QStringLiteral("  a\r\nb\rc\n\u00A0nbsp\t%note% @@ $$ \U0001F4DD tail  ");
+  const QString expected = QStringLiteral("  a\nb\nc\n\u00A0nbsp\t%note% @@ $$ \U0001F4DD tail  ");
+
+  NewNoteDialog2::Options options;
+  options.m_bodyMode = NewNoteDialog2::BodyMode::LiteralContent;
+  options.m_initialContent = captured;
+
+  NewNoteDialog2 dialog(m_newNoteServices, newNoteParentId(), options);
+  QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+
+  acceptNewNoteDialog(dialog, QStringLiteral("capture_verbatim.md"));
+
+  const NodeIdentifier newId = dialog.getNewNodeId();
+  QVERIFY(newId.isValid());
+  QCOMPARE(readNoteBytes(newId), expected.toUtf8());
+
+  // Caret lands at the end of the captured content (UTF-16 units).
+  QCOMPARE(dialog.getNewCursorOffset(), expected.size());
+}
+
+// The user may clear the captured text entirely; the accepted note is then
+// empty with an offset of zero (NOT the template path's -1 "no content"
+// sentinel, and NOT the original content).
+void TestOpenNotebookDialog2::testNewNoteLiteralClearedAcceptPersistsEmpty() {
+  NewNoteDialog2::Options options;
+  options.m_bodyMode = NewNoteDialog2::BodyMode::LiteralContent;
+  options.m_initialContent = QStringLiteral("discard me");
+
+  NewNoteDialog2 dialog(m_newNoteServices, newNoteParentId(), options);
+  QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+
+  auto *contentEdit = dialog.findChild<QPlainTextEdit *>(QStringLiteral("newNoteContentEdit"));
+  QVERIFY(contentEdit);
+  contentEdit->clear();
+
+  acceptNewNoteDialog(dialog, QStringLiteral("capture_cleared.md"));
+
+  const NodeIdentifier newId = dialog.getNewNodeId();
+  QVERIFY(newId.isValid());
+  QCOMPARE(readNoteBytes(newId), QByteArray());
+  QCOMPARE(dialog.getNewCursorOffset(), 0);
+}
+
+// A capture dialog must neither READ nor OVERWRITE the shared static
+// last-template state that ordinary New Note dialogs restore and save.
+void TestOpenNotebookDialog2::testNewNoteLiteralDoesNotTouchLastTemplate() {
+  // Seed one template so the selector has something to remember.
+  QVERIFY(m_templateSvc->ensureTemplateFolder());
+  const QString templateName = QStringLiteral("capture_probe.md");
+  {
+    QFile f(QDir(m_templateSvc->getTemplateFolder()).filePath(templateName));
+    QVERIFY(f.open(QIODevice::WriteOnly));
+    f.write("template body");
+    f.close();
+  }
+
+  // (a) Ordinary dialog selects the template and is accepted -> remembered.
+  {
+    NewNoteDialog2 dialog(m_newNoteServices, newNoteParentId());
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+    auto *selector = dialog.findChild<NoteTemplateSelector *>();
+    QVERIFY(selector);
+    QVERIFY2(selector->setCurrentTemplate(templateName), "Seeded template must be selectable");
+    acceptNewNoteDialog(dialog, QStringLiteral("last_tpl_a.md"));
+  }
+
+  // (b) A capture dialog runs in between and is accepted.
+  {
+    NewNoteDialog2::Options options;
+    options.m_bodyMode = NewNoteDialog2::BodyMode::LiteralContent;
+    options.m_initialContent = QStringLiteral("captured body");
+
+    NewNoteDialog2 dialog(m_newNoteServices, newNoteParentId(), options);
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+    acceptNewNoteDialog(dialog, QStringLiteral("last_tpl_b.md"));
+  }
+
+  // (c) The next ordinary dialog must still restore the template from (a).
+  {
+    NewNoteDialog2 dialog(m_newNoteServices, newNoteParentId());
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+    auto *selector = dialog.findChild<NoteTemplateSelector *>();
+    QVERIFY(selector);
+    QCOMPARE(selector->getCurrentTemplate(), templateName);
+  }
+}
+
+// =============================================================================
+// Application::dispatchCaptureText
+//
+// The native Objective-C provider does the AppKit pasteboard read and then
+// delegates every decision here, so this seam IS the Service contract.
+// =============================================================================
+
+void TestOpenNotebookDialog2::testDispatchRejectsMissingAndWhitespaceOnly() {
+  const QStringList rejected = {QString(),                   // no pasteboard string at all
+                                QString::fromLatin1(""),     // empty
+                                QStringLiteral("   "),       // spaces
+                                QStringLiteral("\t\n \r\n"), // whitespace mix
+                                QStringLiteral("\n")};
+
+  for (const QString &input : rejected) {
+    int calls = 0;
+    QString error = QStringLiteral("pre-existing");
+    const bool accepted =
+        Application::dispatchCaptureText(input, error, [&calls](const QString &) { ++calls; });
+
+    QVERIFY2(!accepted, "whitespace-only or missing input must be rejected");
+    QVERIFY2(!error.isEmpty(), "a rejection must report a non-empty error");
+    QCOMPARE(calls, 0);
+  }
+}
+
+void TestOpenNotebookDialog2::testDispatchAcceptsTextVerbatim() {
+  // Surrounding whitespace and Unicode must survive untouched: validation may
+  // inspect trimmed(), but it must never trim what it forwards.
+  const QString captured = QStringLiteral("  \u4E2D\u6587 \U0001F4DD tail\t");
+
+  int calls = 0;
+  QString seen;
+  QString error = QStringLiteral("pre-existing");
+
+  const bool accepted =
+      Application::dispatchCaptureText(captured, error, [&](const QString &p_text) {
+        ++calls;
+        seen = p_text;
+      });
+
+  QVERIFY(accepted);
+  QVERIFY2(error.isEmpty(), "an accepted request must clear the error");
+  QCOMPARE(calls, 1);
+  QCOMPARE(seen, captured);
+}
+
+// A true return must mean the request was actually dispatched, so an absent
+// callback is reported as a failure rather than a silent success.
+void TestOpenNotebookDialog2::testDispatchWithoutCallbackIsRefused() {
+  QString error;
+  const bool accepted =
+      Application::dispatchCaptureText(QStringLiteral("some text"), error, nullptr);
+
+  QVERIFY(!accepted);
+  QVERIFY(!error.isEmpty());
 }
 
 } // namespace tests


### PR DESCRIPTION
## Summary

Adds a macOS **"Create Note in VNote"** system Service, so text selected in any
application can be turned into a note without leaving that app. Selecting text →
`Services` → `Create Note in VNote` brings VNote forward and opens the ordinary
New Note dialog pre-filled with the selection.

Windows and Linux are completely unaffected: every AppKit line lives behind
`Q_OS_MACOS`, and the Objective-C++ compilation is enabled only under `if(APPLE)`.

## Design

| Layer | Responsibility |
|---|---|
| `Application` | Platform boundary only. The Objective-C `VNoteServiceProvider` reads the pasteboard and delegates every decision to the platform-independent `Application::dispatchCaptureText` seam, then emits `captureNoteRequested`. Mirrors the existing `QEvent::FileOpen` → `openFileRequested` path. |
| `PendingCaptureDispatcher` | Non-UI FIFO + readiness bit + reentrancy guard owned by `MainWindow2`, shaped like the existing `m_pendingOpenBatches` queue. Header-inline so tests need not compile `mainwindow2.cpp`. |
| `NotebookExplorer2` (View) | Owns the single `QDialog` and resolves the destination. |
| `NewNoteDialog2` (View) | Constructor-only `Options`; collects input into `NewNoteInput` and writes nothing. |
| `NewNoteController` | All persistence: writes the captured bytes and computes the caret offset. |

Two ordering rules are load-bearing:

- The capture queue is released **after** `drainPendingOpenBatches()` on
  `ViewArea2::corePropagationReady`, because a capture opens a buffer that must
  land in the restored vxcore workspace.
- `registerServiceProvider()` runs **after** the signal is connected — Apple may
  dispatch a request as soon as the provider is registered.

A request arriving while the capture dialog is up is appended and handled after
that dialog returns, so the modal never nests.

## Verbatim capture

The captured text is read with `QTextDocument::toRawText()`, **not**
`toPlainText()`, which is documented to silently rewrite `U+00A0` to a plain
space and `U+2028`/`U+2029` to LF. The only permitted mutation is CRLF / lone CR
collapsing to LF. Nothing is trimmed, and literal mode never touches the snippet
or template engine, so `%note%`, `@@` and `$$` stay literal.

Ordinary New Note behaviour is unchanged, including the shared `s_lastTemplate`
state, which a capture dialog neither reads nor overwrites.

## Packaging

The bundle plist is now wired through `MACOSX_BUNDLE_INFO_PLIST` instead of being
copied by the `deploy` target, so an ordinary app build already advertises the
Service and packaging cannot diverge from the built bundle.

## Tests

- `test_newnotecontroller` (+2): verbatim persistence of markers, whitespace, a
  tab and a supplementary-plane character; cleared content → empty note, offset 0.
- `test_notebookexplorer2_state` (+4): dispatcher queueing before readiness, FIFO
  drain, idempotent `setReady()`, and handler depth never exceeding 1 under a
  simulated nested request.
- `test_open_notebook_dialog2` (+8): per-mode control existence, an end-to-end
  accept asserting the **persisted bytes** (incl. `U+00A0` survival — this test
  fails against a `toPlainText()` implementation), cleared-accept, `s_lastTemplate`
  isolation, and the dispatch seam's reject/accept/no-callback contract.
- `tests/CMakeLists.txt`: Apple-only `plutil` / `PlistBuddy` CTest assertions
  pinning the exact `NSServices` keys, types, and the deliberate absence of
  `NSReturnTypes`, against the **built bundle** plist.

## Validation

Windows / Qt 6.10.3: full build clean, `ctest` **185/185 passed** on this branch
rebased onto `master`. The Apple-only plist tests and the manual Service-menu
scenarios need a Mac and are covered by CI here.
